### PR TITLE
Wrapify 0.2 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@ Wrapify is a middleware communication wrapper for transmitting data across nodes
 alter the operation pipeline of your python scripts. Wrapify introduces
 a number of helper functions to make middleware integration possible without the need to learn an entire framework, just to parallelize your processes on 
 multiple machines. 
-Wrapify is currently compatible with the[Yarp python bindings](https://www.yarp.it/yarp_swig.html) package only, but can be extended to support other middleware
-platforms.
+Wrapify supports [Yarp](https://www.yarp.it/yarp_swig.html) and [ROS](http://wiki.ros.org/rospy).
 
 To Wrapify a class, simply add the decorators describing the publisher and listener parameters. Wrapify imposes an object-oriented
 requirement on your coding style: All wrapify compatible functions need to be defined within a class. 
 
 ## Installation
 
-Before using Wrapify, Yarp must be installed. Follow the [Yarp installation guide](docs/yarp_install.md#installing-yarp).
+Before using Wrapify, Yarp or ROS must be installed. Follow the [Yarp installation guide](docs/yarp_install.md#installing-yarp).
 Note that the iCub package is not needed for Wrapify to work and does not have to be installed if you do not intend on using the iCub robot.
+For installation of ROS, follow the [ROS installation guide](docs/ros_install.md#installing-ros). 
+We recommend installing ROS on conda using the [RoboStack](https://github.com/RoboStack/ros-noetic) environment.
 
 #### compatibility
 * Python >= 3.6
-* Yarp >= v3.3.2 
 * OpenCV >= 4.2
+* Yarp >= v3.3.2 
+* ROS Noetic Ninjemys
 
 To install Warpify:
 
@@ -107,7 +109,15 @@ For more examples on usage, refer to the [usage documentation](docs/usage.md). R
 
 # TODO
 Visit the issues section for more details 
-* [ ] **Support ROS**
-* [ ] **Support encapsulating wrapped calls to publishers and listeners**
+* [x] **Support ROS**
+* [ ] **Support ROS 2**
+* [ ] **Support ZeroMQ**
+* [x] **Support Pytorch**
+* [x] **Support Tensorflow 2**
+* [x] **Support Keras (TF 2)**
+* [ ] **Support Pandas dataframes**
+* [ ] **Support Image formats: tensorflow, Pytorch, Scikit Image, ImageIO and Pillow**
+* [ ] **Support msgpack as a serialization format**
+* [x] **Support encapsulating wrapped calls to publishers and listeners**
 * [ ] **Support wrapping for module functions**
 * [ ] **Support multiple class instances for functions set to publish**

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,5 @@ pip3 install requirements.txt -r
 All python scripts in this directory are runnable. Each script contains instructions on running the process under `Run`
 
 For all scripts (with Yarp) the `yarpserver` command must be running in a standalone terminal.
+
+For all scripts (with ROS) the `roscore` command must be running in a standalone terminal.

--- a/examples/audio_video.py
+++ b/examples/audio_video.py
@@ -61,6 +61,7 @@ class CamMic(MiddlewareCommunicator):
             self.vid_cap = cv2.VideoCapture(img_source)
             self.enable_video = True
         else:
+            self.vid_cap = None
             self.enable_video = False
 
         self.last_img = None
@@ -109,8 +110,9 @@ class CamMic(MiddlewareCommunicator):
             self.collect_cam(img_width=self.img_width, img_height=self.img_height)
         self.collect_mic(audio, aud_rate=self.aud_rate, aud_chunk=self.aud_chunk, aud_channels=self.aud_channels)
 
-    def __del__(self, exc_type, exc_val, exc_tb):
-        self.vid_cap.release()
+    def __del__(self):
+        if self.vid_cap:
+            self.vid_cap.release()
 
  
 def parse_args():

--- a/examples/audio_video.py
+++ b/examples/audio_video.py
@@ -155,12 +155,12 @@ if __name__ == "__main__":
                                             aud_port=args.aud_port, aud_port_connect=args.aud_port_connect)
 
     if args.mode == "publish":
-        cam_mic.activate_communication("collect_cam", mode="publish")
-        cam_mic.activate_communication("collect_mic", mode="publish")
+        cam_mic.activate_communication(CamMic.collect_cam, mode="publish")
+        cam_mic.activate_communication(CamMic.collect_mic, mode="publish")
         cam_mic.capture_cam_mic()
     if args.mode == "listen":
-        cam_mic.activate_communication("collect_cam", mode="listen")
-        cam_mic.activate_communication("collect_mic", mode="listen")
+        cam_mic.activate_communication(CamMic.collect_cam, mode="listen")
+        cam_mic.activate_communication(CamMic.collect_mic, mode="listen")
 
         while True:
             if "audio" in args.stream:

--- a/examples/audio_video.py
+++ b/examples/audio_video.py
@@ -96,7 +96,7 @@ class CamMic(MiddlewareCommunicator):
     def capture_cam_mic(self):
         if self.enable_audio:
             # capture the audio stream from the microphone
-            with sd.InputStream(device=self.aud_source, channels=self.aud_channels, callback=self.__mic_callback__,
+            with sd.InputStream(device=self.aud_source, channels=self.aud_channels, callback=self._mic_callback,
                             blocksize=self.aud_chunk,
                             samplerate=self.aud_rate):
                 while True:
@@ -105,7 +105,7 @@ class CamMic(MiddlewareCommunicator):
             while True:
                 self.collect_cam()
 
-    def __mic_callback__(self, audio, frames, time, status):
+    def _mic_callback(self, audio, frames, time, status):
         if self.enable_video:
             self.collect_cam(img_width=self.img_width, img_height=self.img_height)
         self.collect_mic(audio, aud_rate=self.aud_rate, aud_chunk=self.aud_chunk, aud_channels=self.aud_channels)

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -57,6 +57,7 @@ class CamMic(MiddlewareCommunicator):
             self.vid_cap = cv2.VideoCapture(img_source)
             self.enable_video = True
         else:
+            self.vid_cap = None
             self.enable_video = False
 
     @MiddlewareCommunicator.register("Image", "yarp", "CamMic", "/cam_mic/cam_feed",
@@ -100,8 +101,9 @@ class CamMic(MiddlewareCommunicator):
         self.collect_mic(audio, aud_rate=self.aud_rate, aud_chunk=self.aud_chunk, aud_channels=self.aud_channels)
         print(audio.flatten(), audio.min(), audio.mean(), audio.max())
 
-    def __del__(self, exc_type, exc_val, exc_tb):
-        self.vid_cap.release()
+    def __del__(self):
+        if self.vid_cap:
+            self.vid_cap.release()
 
 
 def parse_args():

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -32,77 +32,10 @@ Run:
     python3 cam_mic.py --mode listen --stream audio video
 """
 
-
-class CamMic(MiddlewareCommunicator):
-    __registry__ = {}
-
-    def __init__(self, *args, stream=("audio", "video"), aud_source=0,
-                 aud_rate=44100, aud_chunk=10000, aud_channels=1, img_source=0,
-                 img_width=320, img_height=240, **kwargs):
-        super(MiddlewareCommunicator, self).__init__()
-        self.aud_source = aud_source
-        self.aud_rate = aud_rate
-        self.aud_chunk = aud_chunk
-        self.aud_channels = aud_channels
-        
-        self.img_source = img_source
-        self.img_width = img_width
-        self.img_height = img_height
-
-        self.enable_audio = "audio" in stream
-        self.enable_video = self.vid_cap = "video" in stream
-
-    @MiddlewareCommunicator.register("Image", "yarp", "CamMic", "/cam_mic/cam_feed", carrier="", width="$img_width", height="$img_height", rgb=True)
-    def collect_cam(self, img_width=320, img_height=240):
-        if self.vid_cap is True:
-            self.vid_cap = cv2.VideoCapture(self.img_source)
-            if img_width > 0 and img_height > 0:
-                self.vid_cap.set(cv2.CAP_PROP_FRAME_WIDTH, img_width)
-                self.vid_cap.set(cv2.CAP_PROP_FRAME_HEIGHT, img_height)
-            if not self.vid_cap.isOpened():
-                self.vid_cap.release()
-                self.vid_cap = False
-        if self.vid_cap:
-            grabbed, img = self.vid_cap.read()
-            if grabbed:
-                print("Video frame grabbed")
-            else:
-                print("Video frame not grabbed")
-                img = np.random.randint(256, size=(img_height, img_width, 3), dtype=np.uint8)
-        else:
-            print("Video capturer not opened")
-            img = np.random.randint(256, size=(img_height, img_width, 3), dtype=np.uint8)
-        return img,
-
-    @MiddlewareCommunicator.register("AudioChunk", "yarp", "CamMic", "/cam_mic/audio_feed", carrier="", rate="$aud_rate", chunk="$aud_chunk", channels="$aud_channels")
-    def collect_mic(self, aud=None, aud_rate=44100, aud_chunk=int(44100/5), aud_channels=1):
-        aud = aud, aud_rate
-        return aud,
-
-    def capture_cam_mic(self):
-        if self.enable_audio:
-            # capture the audio stream from the microphone
-            with sd.InputStream(device=self.aud_source, channels=self.aud_channels, callback=self._mic_callback, blocksize=self.aud_chunk, samplerate=self.aud_rate):
-                while True:
-                    pass
-        elif self.enable_video:
-            while True:
-                self.collect_cam()
-
-    def _mic_callback(self, audio, frames, time, status):
-        if self.enable_video:
-            self.collect_cam(img_width=self.img_width, img_height=self.img_height)
-        self.collect_mic(audio, aud_rate=self.aud_rate, aud_chunk=self.aud_chunk, aud_channels=self.aud_channels)
-        print(audio.flatten(), audio.min(), audio.mean(), audio.max())
-
-    def __del__(self):
-        if not isinstance(self.vid_cap, bool):
-            self.vid_cap.release()
-
-
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", type=str, default="publish", choices={"publish", "listen"}, help="The transmission mode")
+    parser.add_argument("--mware", type=str, default="yarp", choices={"yarp", "ros"}, help="The middleware to use for transmission")
     parser.add_argument("--stream", nargs="+", default=["video", "audio"], choices={"video", "audio"}, help="The streamed sensor data")
     parser.add_argument("--img-source", type=int, default=0, help="The video capture device id (int camera id)")
     parser.add_argument("--img-width", type=int, default=320, help="The image width")
@@ -113,16 +46,82 @@ def parse_args():
     parser.add_argument("--aud-chunk", type=int, default=10000, help="The transmitted audio chunk size")
     return parser.parse_args()
 
-
 if __name__ == "__main__":
     args = parse_args()
 
+    class CamMic(MiddlewareCommunicator):
+        __registry__ = {}
+
+        def __init__(self, *args, stream=("audio", "video"), aud_source=0,
+                     aud_rate=44100, aud_chunk=10000, aud_channels=1, img_source=0,
+                     img_width=320, img_height=240, **kwargs):
+            super(MiddlewareCommunicator, self).__init__()
+            self.aud_source = aud_source
+            self.aud_rate = aud_rate
+            self.aud_chunk = aud_chunk
+            self.aud_channels = aud_channels
+
+            self.img_source = img_source
+            self.img_width = img_width
+            self.img_height = img_height
+
+            self.enable_audio = "audio" in stream
+            self.enable_video = self.vid_cap = "video" in stream
+
+        @MiddlewareCommunicator.register("Image", args.mware, "CamMic", "/cam_mic/cam_feed", carrier="", width="$img_width", height="$img_height", rgb=True)
+        def collect_cam(self, img_width=320, img_height=240):
+            if self.vid_cap is True:
+                self.vid_cap = cv2.VideoCapture(self.img_source)
+                if img_width > 0 and img_height > 0:
+                    self.vid_cap.set(cv2.CAP_PROP_FRAME_WIDTH, img_width)
+                    self.vid_cap.set(cv2.CAP_PROP_FRAME_HEIGHT, img_height)
+                if not self.vid_cap.isOpened():
+                    self.vid_cap.release()
+                    self.vid_cap = False
+            if self.vid_cap:
+                grabbed, img = self.vid_cap.read()
+                if grabbed:
+                    print("Video frame grabbed")
+                else:
+                    print("Video frame not grabbed")
+                    img = np.random.randint(256, size=(img_height, img_width, 3), dtype=np.uint8)
+            else:
+                print("Video capturer not opened")
+                img = np.random.randint(256, size=(img_height, img_width, 3), dtype=np.uint8)
+            return img,
+
+        @MiddlewareCommunicator.register("AudioChunk", args.mware, "CamMic", "/cam_mic/audio_feed", carrier="", rate="$aud_rate", chunk="$aud_chunk", channels="$aud_channels")
+        def collect_mic(self, aud=None, aud_rate=44100, aud_chunk=int(44100 / 5), aud_channels=1):
+            aud = aud, aud_rate
+            return aud,
+
+        def capture_cam_mic(self):
+            if self.enable_audio:
+                # capture the audio stream from the microphone
+                with sd.InputStream(device=self.aud_source, channels=self.aud_channels, callback=self._mic_callback, blocksize=self.aud_chunk, samplerate=self.aud_rate):
+                    while True:
+                        pass
+            elif self.enable_video:
+                while True:
+                    self.collect_cam()
+
+        def _mic_callback(self, audio, frames, time, status):
+            if self.enable_video:
+                self.collect_cam(img_width=self.img_width, img_height=self.img_height)
+            self.collect_mic(audio, aud_rate=self.aud_rate, aud_chunk=self.aud_chunk, aud_channels=self.aud_channels)
+            print(audio.flatten(), audio.min(), audio.mean(), audio.max())
+
+        def __del__(self):
+            if not isinstance(self.vid_cap, bool):
+                self.vid_cap.release()
+
     cam_mic = CamMic(stream=args.stream, aud_source=args.aud_source)
+
     if args.mode == "publish":
         cam_mic.activate_communication(CamMic.collect_cam, mode="publish")
         cam_mic.activate_communication(CamMic.collect_mic, mode="publish")
         cam_mic.capture_cam_mic()
-    if args.mode == "listen":
+    elif args.mode == "listen":
         cam_mic.activate_communication(CamMic.collect_cam, mode="listen")
         cam_mic.activate_communication(CamMic.collect_mic, mode="listen")
         while True:

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -126,9 +126,9 @@ if __name__ == "__main__":
         cam_mic.activate_communication(CamMic.collect_mic, mode="listen")
         while True:
             if "audio" in args.stream:
-                aud, = cam_mic.collect_mic(aud_rate=args.aud_rate, aud_chunk=args.aud_chunk, aud_channels=args.aud_channels)
+                (aud, aud_rate), = cam_mic.collect_mic(aud_rate=args.aud_rate, aud_chunk=args.aud_chunk, aud_channels=args.aud_channels)
             else:
-                aud = None
+                aud = aud_rate = None
             if "video" in args.stream:
                 img, = cam_mic.collect_cam(img_source=args.img_source, img_width=args.img_width, img_height=args.img_height)
             else:
@@ -137,6 +137,6 @@ if __name__ == "__main__":
                 cv2.imshow("Received image", img)
                 cv2.waitKey(1)
             if aud is not None:
-                print(aud)
-                sd.play(aud[0].flatten(), samplerate=aud[1])
+                print(aud.flatten(), aud.min(), aud.mean(), aud.max())
+                sd.play(aud.flatten(), samplerate=aud_rate)
                 sd.wait(1)

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
             else:
                 img = None
             if img is not None:
-                cv2.imshow("Received Image", img)
+                cv2.imshow("Received image", img)
                 cv2.waitKey(1)
             if aud is not None:
                 print(aud)

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -86,16 +86,14 @@ class CamMic(MiddlewareCommunicator):
     def capture_cam_mic(self):
         if self.enable_audio:
             # capture the audio stream from the microphone
-            with sd.InputStream(device=self.aud_source, channels=self.aud_channels, callback=self.__mic_callback__,
-                            blocksize=self.aud_chunk,
-                            samplerate=self.aud_rate):
+            with sd.InputStream(device=self.aud_source, channels=self.aud_channels, callback=self._mic_callback, blocksize=self.aud_chunk, samplerate=self.aud_rate):
                 while True:
                     pass
         elif self.enable_video:
             while True:
                 self.collect_cam()
 
-    def __mic_callback__(self, audio, frames, time, status):
+    def _mic_callback(self, audio, frames, time, status):
         if self.enable_video:
             self.collect_cam(img_width=self.img_width, img_height=self.img_height)
         self.collect_mic(audio, aud_rate=self.aud_rate, aud_chunk=self.aud_chunk, aud_channels=self.aud_channels)

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -123,12 +123,12 @@ if __name__ == "__main__":
 
     cam_mic = CamMic(stream=args.stream, aud_source=args.aud_source)
     if args.mode == "publish":
-        cam_mic.activate_communication("collect_cam", mode="publish")
-        cam_mic.activate_communication("collect_mic", mode="publish")
+        cam_mic.activate_communication(CamMic.collect_cam, mode="publish")
+        cam_mic.activate_communication(CamMic.collect_mic, mode="publish")
         cam_mic.capture_cam_mic()
     if args.mode == "listen":
-        cam_mic.activate_communication("collect_cam", mode="listen")
-        cam_mic.activate_communication("collect_mic", mode="listen")
+        cam_mic.activate_communication(CamMic.collect_cam, mode="listen")
+        cam_mic.activate_communication(CamMic.collect_mic, mode="listen")
         while True:
             if "audio" in args.stream:
                 aud, = cam_mic.collect_mic(aud_rate=args.aud_rate, aud_chunk=args.aud_chunk, aud_channels=args.aud_channels)

--- a/examples/cam_mic.py
+++ b/examples/cam_mic.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
             self.enable_audio = "audio" in stream
             self.enable_video = self.vid_cap = "video" in stream
 
-        @MiddlewareCommunicator.register("Image", args.mware, "CamMic", "/cam_mic/cam_feed", carrier="", width="$img_width", height="$img_height", rgb=True)
+        @MiddlewareCommunicator.register("Image", args.mware, "CamMic", "/cam_mic/cam_feed", carrier="", width="$img_width", height="$img_height", rgb=True, queue_size=10)
         def collect_cam(self, img_width=320, img_height=240):
             if self.vid_cap is True:
                 self.vid_cap = cv2.VideoCapture(self.img_source)

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -5,7 +5,7 @@ Commands for Running Examples
 yarpserver
 
 # Run first in every new terminal that you open (adjust paths!)
-cd ~/Code/wrapify && conda activate yarp && export PYTHONPATH=~/Code/wrapify
+cd ~/Code/wrapify && conda activate yarp && export PYTHONPATH=~/Code/wrapify:/opt/ros/noetic/lib/python3/dist-packages
 
 # To kill something that Ctrl+C won't kill use Ctrl+Alt+C or...
 Ctrl+Z

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -31,9 +31,9 @@ python3 examples/torch_tensor.py --mode publish  [--mware ros]
 python3 examples/torch_tensor.py --mode listen  [--mware ros]
 
 # Run camera example
-python3 examples/cam_mic.py --mode publish --stream video --img-source 0
-python3 examples/cam_mic.py --mode listen --stream video
+python3 examples/cam_mic.py --mode publish --stream video --img-source 0  [--mware ros]
+python3 examples/cam_mic.py --mode listen --stream video  [--mware ros]
 
 # Run audio example
-python3 examples/cam_mic.py --mode publish --stream audio --aud-source 0
-python3 examples/cam_mic.py --mode listen --stream audio
+python3 examples/cam_mic.py --mode publish --stream audio --aud-source 0  [--mware ros]
+python3 examples/cam_mic.py --mode listen --stream audio  [--mware ros]

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -3,6 +3,7 @@ Commands for Running Examples
 
 # Leave running in a separate terminal before running any example
 yarpserver
+roscore
 
 # Run first in every new terminal that you open (adjust paths!)
 cd ~/Code/wrapify && conda activate yarp && export PYTHONPATH=~/Code/wrapify:/opt/ros/noetic/lib/python3/dist-packages
@@ -14,20 +15,20 @@ kill -SIGTERM %1
 -----------------------------------------------------------------------------------------
 
 # Run hello world example
-python3 examples/hello_world.py --publish
-python3 examples/hello_world.py --listen
+python3 examples/hello_world.py --publish  [--mware ros]
+python3 examples/hello_world.py --listen  [--mware ros]
 
 # Run encapsulation example
-python3 examples/encapsulation.py --publish
-python3 examples/encapsulation.py --listen
+python3 examples/encapsulation.py --publish  [--mware ros]
+python3 examples/encapsulation.py --listen  [--mware ros]
 
 # Run object notify example
-python3 examples/object_notify.py --mode publish
-python3 examples/object_notify.py --mode listen
+python3 examples/object_notify.py --mode publish  [--mware ros]
+python3 examples/object_notify.py --mode listen  [--mware ros]
 
 # Run torch tensor example
-python3 examples/torch_tensor.py --mode publish
-python3 examples/torch_tensor.py --mode listen
+python3 examples/torch_tensor.py --mode publish  [--mware ros]
+python3 examples/torch_tensor.py --mode listen  [--mware ros]
 
 # Run camera example
 python3 examples/cam_mic.py --mode publish --stream video --img-source 0

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -25,6 +25,10 @@ python3 examples/encapsulation.py --listen
 python3 examples/object_notify.py --mode publish
 python3 examples/object_notify.py --mode listen
 
+# Run torch tensor example
+python3 examples/torch_tensor.py --mode publish
+python3 examples/torch_tensor.py --mode listen
+
 # Run camera example
 python3 examples/cam_mic.py --mode publish --stream video --img-source 0
 python3 examples/cam_mic.py --mode listen --stream video

--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -1,0 +1,34 @@
+Commands for Running Examples
+=============================
+
+# Leave running in a separate terminal before running any example
+yarpserver
+
+# Run first in every new terminal that you open (adjust paths!)
+cd ~/Code/wrapify && conda activate yarp && export PYTHONPATH=~/Code/wrapify
+
+# To kill something that Ctrl+C won't kill use Ctrl+Alt+C or...
+Ctrl+Z
+kill -SIGTERM %1
+
+-----------------------------------------------------------------------------------------
+
+# Run hello world example
+python3 examples/hello_world.py --publish
+python3 examples/hello_world.py --listen
+
+# Run encapsulation example
+python3 examples/encapsulation.py --publish
+python3 examples/encapsulation.py --listen
+
+# Run object notify example
+python3 examples/object_notify.py --mode publish
+python3 examples/object_notify.py --mode listen
+
+# Run camera example
+python3 examples/cam_mic.py --mode publish --stream video --img-source 0
+python3 examples/cam_mic.py --mode listen --stream video
+
+# Run audio example
+python3 examples/cam_mic.py --mode publish --stream audio --aud-source 0
+python3 examples/cam_mic.py --mode listen --stream audio

--- a/examples/encapsulation.py
+++ b/examples/encapsulation.py
@@ -24,8 +24,8 @@ parser.add_argument("--listen", dest="mode", action="store_const", const="listen
 args = parser.parse_args()
 
 encapsulator = Encapsulator()
-encapsulator.activate_communication("encapsulating_send_message", mode=args.mode)
-encapsulator.activate_communication("encapsulated_modify_message", mode=args.mode)
+encapsulator.activate_communication(Encapsulator.encapsulating_send_message, mode=args.mode)
+encapsulator.activate_communication(Encapsulator.encapsulated_modify_message, mode=args.mode)
 
 while True:
     my_message, = encapsulator.encapsulating_send_message()

--- a/examples/encapsulation.py
+++ b/examples/encapsulation.py
@@ -1,16 +1,20 @@
 import argparse
 from wrapify.connect.wrapper import MiddlewareCommunicator
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--publish", dest="mode", action="store_const", const="publish", default="listen", help="Publish mode")
+parser.add_argument("--listen", dest="mode", action="store_const", const="listen", default="listen", help="Listen mode (default)")
+parser.add_argument("--mware", type=str, default="yarp", choices={"yarp", "ros"}, help="The middleware to use for transmission")
+args = parser.parse_args()
+
 
 class Encapsulator(MiddlewareCommunicator):
-    @MiddlewareCommunicator.register("NativeObject", "yarp", "Encapsulator", "/encapsulator/my_message_modifier",
-                                     carrier="", should_wait=True)
-    def encapsulated_modify_message(self, msg):
-        msg = "******" + msg + "******"
-        return msg,
 
-    @MiddlewareCommunicator.register("NativeObject", "yarp", "Encapsulator", "/encapsulator/my_message",
-                                     carrier="", should_wait=True)
+    @MiddlewareCommunicator.register("NativeObject", args.mware, "Encapsulator", "/encapsulator/my_message_modifier", carrier="", should_wait=True)
+    def encapsulated_modify_message(self, msg):
+        return f"****** {msg} ******",
+
+    @MiddlewareCommunicator.register("NativeObject", args.mware, "Encapsulator", "/encapsulator/my_message", carrier="", should_wait=True)
     def encapsulating_send_message(self):
         msg = input("Type your message: ")
         msg, = self.encapsulated_modify_message(msg)
@@ -18,15 +22,10 @@ class Encapsulator(MiddlewareCommunicator):
         return obj,
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--publish", dest="mode", action="store_const", const="publish", default="listen", help="Publish mode")
-parser.add_argument("--listen", dest="mode", action="store_const", const="listen", default="listen", help="Listen mode (default)")
-args = parser.parse_args()
-
 encapsulator = Encapsulator()
 encapsulator.activate_communication(Encapsulator.encapsulating_send_message, mode=args.mode)
 encapsulator.activate_communication(Encapsulator.encapsulated_modify_message, mode=args.mode)
 
 while True:
     my_message, = encapsulator.encapsulating_send_message()
-    print(my_message["message"])
+    print("Method result:", my_message["message"])

--- a/examples/encapsulation.py
+++ b/examples/encapsulation.py
@@ -26,6 +26,7 @@ encapsulator = Encapsulator()
 encapsulator.activate_communication(Encapsulator.encapsulating_send_message, mode=args.mode)
 encapsulator.activate_communication(Encapsulator.encapsulated_modify_message, mode=args.mode)
 
+encapsulator.encapsulated_modify_message('')
 while True:
     my_message, = encapsulator.encapsulating_send_message()
     print("Method result:", my_message["message"])

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -17,7 +17,7 @@ parser.add_argument("--listen", dest="mode", action="store_const", const="listen
 args = parser.parse_args()
 
 hello_world = HelloWorld()
-hello_world.activate_communication("send_message", mode=args.mode)
+hello_world.activate_communication(HelloWorld.send_message, mode=args.mode)
 
 while True:
     my_message, = hello_world.send_message()

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,24 +1,25 @@
 import argparse
 from wrapify.connect.wrapper import MiddlewareCommunicator
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--publish", dest="mode", action="store_const", const="publish", default="listen", help="Publish mode")
+parser.add_argument("--listen", dest="mode", action="store_const", const="listen", default="listen", help="Listen mode (default)")
+parser.add_argument("--mware", type=str, default="yarp", choices={"yarp", "ros"}, help="The middleware to use for transmission")
+args = parser.parse_args()
+
 
 class HelloWorld(MiddlewareCommunicator):
-    @MiddlewareCommunicator.register("NativeObject", "yarp", "HelloWorld", "/hello/my_message",
-                                     carrier="", should_wait=True)
+
+    @MiddlewareCommunicator.register("NativeObject", args.mware, "HelloWorld", "/hello/my_message", carrier="", should_wait=True)
     def send_message(self):
         msg = input("Type your message: ")
         obj = {"message": msg}
         return obj,
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--publish", dest="mode", action="store_const", const="publish", default="listen", help="Publish mode")
-parser.add_argument("--listen", dest="mode", action="store_const", const="listen", default="listen", help="Listen mode (default)")
-args = parser.parse_args()
-
 hello_world = HelloWorld()
 hello_world.activate_communication(HelloWorld.send_message, mode=args.mode)
 
 while True:
     my_message, = hello_world.send_message()
-    print(my_message["message"])
+    print("Method result:", my_message["message"])

--- a/examples/icub_head.py
+++ b/examples/icub_head.py
@@ -69,7 +69,7 @@ class ICub(MiddlewareCommunicator, yarp.RFModule):
         self._ienc.getEncoders(self._encs.data())
 
         # control the listening properties from within the app
-        self.activate_communication("receive_images", "listen")
+        self.activate_communication(ICub.receive_images, "listen")
 
     def reset_gaze(self):
         """

--- a/examples/icub_head.py
+++ b/examples/icub_head.py
@@ -108,12 +108,9 @@ class ICub(MiddlewareCommunicator, yarp.RFModule):
         self._curr_head = list(head)
         self._curr_eyes = list(eyes)
 
-    @MiddlewareCommunicator.register("Image", "yarp", "ICub", "$port_cam",
-                                     carrier="", width=320, height=240, rgb=True)
-    @MiddlewareCommunicator.register("Image", "yarp", "ICub", "$port_cam_left",
-                                     carrier="", width=320, height=240, rgb=True)
-    @MiddlewareCommunicator.register("Image", "yarp", "ICub", "$port_cam_right",
-                                     carrier="", width=320, height=240, rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "ICub", "$port_cam", carrier="", width=320, height=240, rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "ICub", "$port_cam_left", carrier="", width=320, height=240, rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "ICub", "$port_cam_right", carrier="", width=320, height=240, rgb=True)
     def receive_images(self, port_cam, port_cam_left, port_cam_right):
         external_cam, left_cam, right_cam = None, None, None
         return external_cam, left_cam, right_cam

--- a/examples/numpy_arrays.py
+++ b/examples/numpy_arrays.py
@@ -1,21 +1,21 @@
 import argparse
-import torch
+import numpy as np
 
 from wrapify.connect.wrapper import MiddlewareCommunicator
 
 """
-A message publisher and listener for torch tensors
+A message publisher and listener for native python objects and numpy arrays
 
-Here we demonstrate
+Here we demonstrate 
 1. Using the NativeObject message
-2. Transmit a nested dummy python object with native objects and multidim torch tensors
+2. Transmit a nested dummy python object with native objects and multidim numpy arrays
 3. Demonstrating the responsive transmission
 
 Run:
     # On machine 1 (or process 1): Publisher waits for keyboard and transmits message
-    python3 torch_tensor.py --mode publish
+    python3 numpy_arrays.py --mode publish
     # On machine 2 (or process 2): Listener waits for message and prints the entire dummy object
-    python3 torch_tensor.py --mode listen
+    python3 numpy_arrays.py --mode listen
 
 """
 
@@ -32,12 +32,12 @@ if __name__ == "__main__":
 
     class Notify(MiddlewareCommunicator):
 
-        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_exchange",
-                                         carrier="", should_wait=True, load_torch_device='cpu')
+        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_exchange", carrier="", should_wait=True)
         def exchange_object(self, msg):
-            ret = {"message": msg,
-                   "torch_ones": torch.ones((2, 4), device='cpu'),
-                   "torch_zeros_cuda": torch.zeros((2, 3), device='cuda')}
+            ret = [{"message": msg,
+                    "numpy": np.ones((2, 4)),
+                    "set": {'a', 1, None},
+                    "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2, 3))}]
             return ret,
 
     notify = Notify()

--- a/examples/object_notify.py
+++ b/examples/object_notify.py
@@ -1,7 +1,5 @@
 import argparse
-
 import numpy as np
-
 
 from wrapify.connect.wrapper import MiddlewareCommunicator
 
@@ -13,7 +11,6 @@ Here we demonstrate
 2. Transmit a nested dummy python object with native objects and multidim numpy arrays
 3. Demonstrating the responsive transmission
 
-
 Run:
     # On machine 1 (or process 1): Publisher waits for keyboard and transmits message. (First message is ignored)
     python3 object_notify.py --mode publish
@@ -23,21 +20,17 @@ Run:
 """
 
 class Notify(MiddlewareCommunicator):
-    @MiddlewareCommunicator.register("NativeObject", "yarp", "Notify", "/notify/test_native_bottle_exchange",
-                                     carrier="", should_wait=True)
+    @MiddlewareCommunicator.register("NativeObject", "yarp", "Notify", "/notify/test_native_bottle_exchange", carrier="", should_wait=True)
     def exchange_object(self, msg):
-        obj = [{"message": msg,
-               "numpy": np.ones((2, 4, 6, 8, 10)),
-               "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2,3,4))}]
-        return obj,
-
+        ret = [{"message": msg,
+                "numpy": np.ones((2, 4)),
+                "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2, 3))}]
+        return ret,
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", type=str, default="publish", choices={"publish", "listen"},
-                        help="The transmission mode")
+    parser.add_argument("--mode", type=str, default="publish", choices={"publish", "listen"}, help="The transmission mode")
     return parser.parse_args()
-
 
 if __name__ == "__main__":
     args = parse_args()
@@ -45,14 +38,12 @@ if __name__ == "__main__":
     notify = Notify()
 
     if args.mode == "publish":
-        notify.activate_communication("exchange_object", mode="publish")
+        notify.activate_communication(Notify.exchange_object, mode="publish")
         while True:
             notify.exchange_object(input("Type your message: "))
-    if args.mode == "listen":
-        notify.activate_communication("exchange_object", mode="listen")
+    elif args.mode == "listen":
+        notify.activate_communication(Notify.exchange_object, mode="listen")
         while True:
             obj = notify.exchange_object(None)
             if obj and obj[0] is not None:
                 print(obj)
-
-

--- a/examples/object_notify.py
+++ b/examples/object_notify.py
@@ -43,10 +43,10 @@ if __name__ == "__main__":
     if args.mode == "publish":
         notify.activate_communication(Notify.exchange_object, mode="publish")
         while True:
-            notify.exchange_object(input("Type your message: "))
+            msg_object, = notify.exchange_object(input("Type your message: "))
+            print("Method result:", msg_object)
     elif args.mode == "listen":
         notify.activate_communication(Notify.exchange_object, mode="listen")
         while True:
-            obj = notify.exchange_object(None)
-            if obj and obj[0] is not None:
-                print(obj)
+            msg_object, = notify.exchange_object(None)
+            print("Method result:", msg_object)

--- a/examples/object_notify.py
+++ b/examples/object_notify.py
@@ -24,6 +24,7 @@ class Notify(MiddlewareCommunicator):
     def exchange_object(self, msg):
         ret = [{"message": msg,
                 "numpy": np.ones((2, 4)),
+                "set": {'a', 1, None},
                 "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2, 3))}]
         return ret,
 

--- a/examples/object_notify.py
+++ b/examples/object_notify.py
@@ -19,22 +19,24 @@ Run:
 
 """
 
-class Notify(MiddlewareCommunicator):
-    @MiddlewareCommunicator.register("NativeObject", "yarp", "Notify", "/notify/test_native_bottle_exchange", carrier="", should_wait=True)
-    def exchange_object(self, msg):
-        ret = [{"message": msg,
-                "numpy": np.ones((2, 4)),
-                "set": {'a', 1, None},
-                "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2, 3))}]
-        return ret,
-
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", type=str, default="publish", choices={"publish", "listen"}, help="The transmission mode")
+    parser.add_argument("--mware", type=str, default="yarp", choices={"yarp", "ros"}, help="The middleware to use for transmission")
     return parser.parse_args()
 
 if __name__ == "__main__":
     args = parse_args()
+
+    class Notify(MiddlewareCommunicator):
+
+        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_bottle_exchange", carrier="", should_wait=True)
+        def exchange_object(self, msg):
+            ret = [{"message": msg,
+                    "numpy": np.ones((2, 4)),
+                    "set": {'a', 1, None},
+                    "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2, 3))}]
+            return ret,
 
     notify = Notify()
 

--- a/examples/object_notify.py
+++ b/examples/object_notify.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     class Notify(MiddlewareCommunicator):
 
-        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_bottle_exchange", carrier="", should_wait=True)
+        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_exchange", carrier="", should_wait=True)
         def exchange_object(self, msg):
             ret = [{"message": msg,
                     "numpy": np.ones((2, 4)),

--- a/examples/object_notify.py
+++ b/examples/object_notify.py
@@ -12,7 +12,7 @@ Here we demonstrate
 3. Demonstrating the responsive transmission
 
 Run:
-    # On machine 1 (or process 1): Publisher waits for keyboard and transmits message. (First message is ignored)
+    # On machine 1 (or process 1): Publisher waits for keyboard and transmits message
     python3 object_notify.py --mode publish
     # On machine 2 (or process 2): Listener waits for message and prints the entire dummy object
     python3 object_notify.py --mode listen

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,2 +1,6 @@
 sounddevice
 Pillow
+tensorflow>=2.9.1
+torch>=1.12.1
+torchaudio>=0.12.1
+torchvision>=0.13.1

--- a/examples/tensorflow_tensor.py
+++ b/examples/tensorflow_tensor.py
@@ -1,23 +1,24 @@
 import argparse
-import numpy as np
+import tensorflow
 
 from wrapify.connect.wrapper import MiddlewareCommunicator
 
 """
-A message publisher and listener for native python objects and numpy arrays
+A message publisher and listener for tensorflow tensors
 
-Here we demonstrate 
+Here we demonstrate
 1. Using the NativeObject message
-2. Transmit a nested dummy python object with native objects and multidim numpy arrays
+2. Transmit a nested dummy python object with native objects and multidim tensorflow tensors
 3. Demonstrating the responsive transmission
 
 Run:
     # On machine 1 (or process 1): Publisher waits for keyboard and transmits message
-    python3 object_notify.py --mode publish
+    python3 tensorflow_tensor.py --mode publish
     # On machine 2 (or process 2): Listener waits for message and prints the entire dummy object
-    python3 object_notify.py --mode listen
+    python3 tensorflow_tensor.py --mode listen
 
 """
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -25,17 +26,18 @@ def parse_args():
     parser.add_argument("--mware", type=str, default="yarp", choices={"yarp", "ros"}, help="The middleware to use for transmission")
     return parser.parse_args()
 
+
 if __name__ == "__main__":
     args = parse_args()
 
     class Notify(MiddlewareCommunicator):
 
-        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_exchange", carrier="", should_wait=True)
+        @MiddlewareCommunicator.register("NativeObject", args.mware, "Notify", "/notify/test_native_exchange",
+                                         carrier="", should_wait=True)
         def exchange_object(self, msg):
-            ret = [{"message": msg,
-                    "numpy": np.ones((2, 4)),
-                    "set": {'a', 1, None},
-                    "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": np.zeros((2, 3))}]
+            ret = {"message": msg,
+                   "tf_ones": tensorflow.ones((2, 4)),
+                   "tf_string": tensorflow.constant("This is string")}
             return ret,
 
     notify = Notify()

--- a/examples/torch_tensor.py
+++ b/examples/torch_tensor.py
@@ -1,0 +1,50 @@
+import argparse
+import torch
+
+from wrapify.connect.wrapper import MiddlewareCommunicator
+
+"""
+A message publisher and listener for torch tensors
+
+Here we demonstrate
+1. Using the NativeObject message
+2. Transmit a nested dummy python object with native objects and multidim torch tensors
+3. Demonstrating the responsive transmission
+
+Run:
+    # On machine 1 (or process 1): Publisher waits for keyboard and transmits message. (First message is ignored)
+    python3 torch_tensor.py --mode publish
+    # On machine 2 (or process 2): Listener waits for message and prints the entire dummy object
+    python3 torch_tensor.py --mode listen
+
+"""
+
+class Notify(MiddlewareCommunicator):
+
+    @MiddlewareCommunicator.register("NativeObject", "yarp", "Notify", "/notify/test_native_bottle_exchange", carrier="", should_wait=True, load_torch_device='cpu')
+    def exchange_object(self, msg):
+        ret = [{"message": msg,
+                "tensor": torch.ones((2, 4), device='cpu'),
+                "list": [[[3, 4, 5.677890, 1.2]]]}, "some", "arbitrary", 0.4344, {"other": torch.zeros((2, 3), device='cuda')}]
+        return ret,
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", type=str, default="publish", choices={"publish", "listen"}, help="The transmission mode")
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    notify = Notify()
+
+    if args.mode == "publish":
+        notify.activate_communication(Notify.exchange_object, mode="publish")
+        while True:
+            notify.exchange_object(input("Type your message: "))
+    elif args.mode == "listen":
+        notify.activate_communication(Notify.exchange_object, mode="listen")
+        while True:
+            obj = notify.exchange_object(None)
+            if obj and obj[0] is not None:
+                print(obj)

--- a/examples/torch_tensor.py
+++ b/examples/torch_tensor.py
@@ -12,7 +12,7 @@ Here we demonstrate
 3. Demonstrating the responsive transmission
 
 Run:
-    # On machine 1 (or process 1): Publisher waits for keyboard and transmits message. (First message is ignored)
+    # On machine 1 (or process 1): Publisher waits for keyboard and transmits message
     python3 torch_tensor.py --mode publish
     # On machine 2 (or process 2): Listener waits for message and prints the entire dummy object
     python3 torch_tensor.py --mode listen

--- a/examples/vid_warhol.py
+++ b/examples/vid_warhol.py
@@ -159,8 +159,8 @@ class Warholify(MiddlewareCommunicator):
         out = Image.composite(bg_fg_layer, skin_layer, skin_mask)
         return out
 
-    @MiddlewareCommunicator.register(*[["Image", "yarp", "Warholify", "/vid_warhol/warhol_" + str(x), {"carrier": "tcp", "width": "$img_width", "height": "$img_height"}] for x in range(9)])
-    @MiddlewareCommunicator.register("Image", "Warholify", "/vid_warhol/warhol_combined", carrier="tcp", width = "$img_width", height = "$img_height")
+    @MiddlewareCommunicator.register([["Image", "yarp", "Warholify", "/vid_warhol/warhol_" + str(x), {"carrier": "tcp", "width": "$img_width", "height": "$img_height"}] for x in range(9)])
+    @MiddlewareCommunicator.register("Image", "Warholify", "/vid_warhol/warhol_combined", carrier="tcp", width="$img_width", height="$img_height")
     def combine_to_one(self, warhols, img_width, img_height):
         warhols_new = []
         for warhol in warhols:

--- a/examples/vid_warhol.py
+++ b/examples/vid_warhol.py
@@ -103,8 +103,7 @@ class Warholify(MiddlewareCommunicator):
         else:
             return img
 
-    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/darken_bg",
-                                     carrier="tcp", width="$img_width", height="$img_height", rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/darken_bg", carrier="tcp", width="$img_width", height="$img_height", rgb=True)
     def darken_bg(self, img, color, img_width, img_height):
         img = self.cv2_to_pil(img)
         # composite image on top of a single-color image, effectively turning all transparent parts to that color
@@ -113,8 +112,7 @@ class Warholify(MiddlewareCommunicator):
         masked_img = self.pil_to_cv2(masked_img)
         return masked_img,
 
-    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/color_bg_fg",
-                                     carrier="tcp", width="$img_width", height="$img_height", rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/color_bg_fg", carrier="tcp", width="$img_width", height="$img_height", rgb=True)
     def color_bg_fg(self, img, bg_color, fg_color, img_width, img_height):
         img = self.cv2_to_pil(img)
         # change transparent background to bg_color and change everything non-transparent to fg_color
@@ -124,8 +122,7 @@ class Warholify(MiddlewareCommunicator):
         masked_img = self.pil_to_cv2(masked_img)
         return masked_img,
 
-    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/white_to_color",
-                                     carrier="tcp", width="$img_width", height="$img_height", rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/white_to_color", carrier="tcp", width="$img_width", height="$img_height", rgb=True)
     def white_to_color(self, img, color, img_width, img_height):
         img = self.cv2_to_pil(img).convert('RGBA')
         # change all colors close to white and non-transparent (alpha > 0) to be color
@@ -198,8 +195,7 @@ class Warholify(MiddlewareCommunicator):
 
         return blank_img
 
-    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/feed", carrier="tcp", width="$img_width",
-                                     height="$img_height")
+    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/feed", carrier="tcp", width="$img_width", height="$img_height")
     def capture_vid(self, img_width, img_height):
         if self.vid_cap is None:
             self.vid_cap = cv2.VideoCapture(self.vid_src)
@@ -219,8 +215,7 @@ class Warholify(MiddlewareCommunicator):
             return img
 
 
-    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/final_img",
-                                     carrier="tcp", width="$img_width", height="$img_height", rgb=True)
+    @MiddlewareCommunicator.register("Image", "yarp", "Warholify", "/vid_warhol/final_img", carrier="tcp", width="$img_width", height="$img_height", rgb=True)
     def display(self, img, img_width, img_height):
         cv2.imshow("Warhol", img)
         cv2.waitKey(1)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name             = 'wrapify',
-    version          = '0.1',
+    version          = '0.2',
     description      = 'Wrapify is a wrapper for simplifying Middleware communication',
     url              = 'https://git.informatik.uni-hamburg.de/abawi/wrapify/',
     author           = 'Fares Abawi',

--- a/wrapify/connect/listeners.py
+++ b/wrapify/connect/listeners.py
@@ -1,7 +1,6 @@
 import os
 from glob import glob
 
-
 from wrapify.utils import SingletonOptimized, dynamic_module_import
 
 
@@ -25,12 +24,11 @@ class Listeners(object):
     registry = {}
 
     @classmethod
-    def register(cls, *args):
-        def decorator(fn):
-            cls.registry[args[0]+":"+args[1]] = fn
-            return fn
+    def register(cls, data_type, communicator):
+        def decorator(klass):
+            cls.registry[data_type + ":" + communicator] = klass
+            return klass
         return decorator
-
 
     @staticmethod
     def scan():

--- a/wrapify/connect/listeners.py
+++ b/wrapify/connect/listeners.py
@@ -39,12 +39,11 @@ class Listeners(object):
 
 
 class Listener(object):
-    def __init__(self, name, in_port, carrier="", should_wait=True):
+    def __init__(self, name, in_port, carrier="", should_wait=True, **kwargs):
         self.__name__ = name
         self.in_port = in_port
         self.carrier = carrier
         self.should_wait = should_wait
-
         self.established = False
 
     def establish(self, **kwargs):

--- a/wrapify/connect/listeners.py
+++ b/wrapify/connect/listeners.py
@@ -39,7 +39,7 @@ class Listeners(object):
 
 
 class Listener(object):
-    def __init__(self, name, in_port, carrier="", should_wait=False):
+    def __init__(self, name, in_port, carrier="", should_wait=True):
         self.__name__ = name
         self.in_port = in_port
         self.carrier = carrier

--- a/wrapify/connect/publishers.py
+++ b/wrapify/connect/publishers.py
@@ -46,7 +46,6 @@ class Publisher(object):
         self.out_port = out_port
         self.carrier = carrier
         self.out_port_connect = out_port + ":out" if out_port_connect is None else out_port_connect
-
         self.established = False
 
     def establish(self, **kwargs):

--- a/wrapify/connect/publishers.py
+++ b/wrapify/connect/publishers.py
@@ -1,8 +1,6 @@
 import os
 from glob import glob
 
-import cv2
-
 from wrapify.utils import SingletonOptimized, dynamic_module_import
 
 
@@ -10,10 +8,10 @@ class Publishers(object):
     registry = {}
 
     @classmethod
-    def register(cls, *args):
-        def decorator(fn):
-            cls.registry[args[0]+":"+args[1]] = fn
-            return fn
+    def register(cls, data_type, communicator):
+        def decorator(klass):
+            cls.registry[data_type + ":" + communicator] = klass
+            return klass
         return decorator
 
     @staticmethod

--- a/wrapify/connect/wrapper.py
+++ b/wrapify/connect/wrapper.py
@@ -1,6 +1,5 @@
-from functools import wraps
-import inspect
 import copy
+from functools import wraps
 
 import wrapify.connect.publishers as pub
 import wrapify.connect.listeners as lsn
@@ -17,72 +16,76 @@ class MiddlewareCommunicator(object):
         self.config = ConfigManager(None).config
         if self.__class__.__name__ in self.config:
             for key, value in self.config[self.__class__.__name__].items():
-                self.activate_communication(key, mode=value)
+                self.activate_communication(getattr(self.__class__, key), mode=value)
 
     @classmethod
-    def register(cls, *args, **kwargs):
-        def encapsulate(fnc):
+    def register(cls, data_type, middleware, *args, **kwargs):
+        def encapsulate(func):
             # define the communication message type (single element)
-            if isinstance(args[0], str):
-                return_func_listen = lsn.Listeners.registry[args[0]+":"+args[1]]
-                return_func_publish = pub.Publishers.registry[args[0]+":"+args[1]]
-                return_func_args = args[2:]
+            if isinstance(data_type, str):
+                return_func_type = data_type + ":" + middleware
+                return_func_listen = lsn.Listeners.registry[return_func_type]
+                return_func_publish = pub.Publishers.registry[return_func_type]
+                return_func_args = args
                 return_func_kwargs = kwargs
-                return_func_type = args[0]+":"+args[1]
 
             # define the communication message type (list for single return). NOTE: supports 1 layer depth only
-            elif isinstance(args[0], list):
-                return_func_listen, return_func_publish, \
-                return_func_args, return_func_kwargs, return_func_type = [], [], [], [], []
-                for arg in args:
-                    return_func_listen.append(lsn.Listeners.registry[arg[0]+":"+arg[1]])
-                    return_func_publish.append(pub.Publishers.registry[arg[0]+":"+arg[1]])
+            elif isinstance(data_type, list):
+                return_func_listen, return_func_publish, return_func_args, return_func_kwargs, return_func_type = [], [], [], [], []
+                for arg in data_type:
+                    data_spec = arg[0] + ":" + arg[1]
+                    return_func_listen.append(lsn.Listeners.registry[data_spec])
+                    return_func_publish.append(pub.Publishers.registry[data_spec])
                     return_func_args.append([a for a in arg[2:] if not isinstance(a, dict)])
                     return_func_kwargs.append(*[a for a in arg[2:] if isinstance(a, dict)])
-                    return_func_type.append(arg[0]+":"+arg[1])
+                    return_func_type.append(data_spec)
 
             # define the communication message type (dict for single return). NOTE: supports 1 layer depth only
-            elif isinstance(args[0], dict):
+            elif isinstance(data_type, dict):
                 raise NotImplementedError("Dictionaries are not yet supported as a return type")
 
-            if fnc.__qualname__ in cls.__registry:
-                cls.__registry[fnc.__qualname__]["communicator"].append({
+            else:
+                raise NotImplementedError(f"Return data type not supported yet: {data_type}")
+
+            func_qualname = func.__qualname__
+            if func_qualname in cls.__registry:
+                cls.__registry[func_qualname]["communicator"].append({
                     "return_func_listen": return_func_listen,
                     "return_func_publish": return_func_publish,
                     "return_func_args": return_func_args,
                     "return_func_kwargs": return_func_kwargs,
                     "return_func_type": return_func_type})
             else:
-                cls.__registry[fnc.__qualname__] = {"communicator": [{
+                cls.__registry[func_qualname] = {"communicator": [{
                     "return_func_listen": return_func_listen,
                     "return_func_publish": return_func_publish,
                     "return_func_args": return_func_args,
                     "return_func_kwargs": return_func_kwargs,
                     "return_func_type": return_func_type}]}
-            cls.__registry[fnc.__qualname__]["mode"] = None
+            cls.__registry[func_qualname]["mode"] = None
 
-            @wraps(fnc)
-            def wrapper(*wds, **kwds):
-                # triggers on calling the function
-                instance_address = str(wds).split(" ")[-1].rstrip(",)")
-                instance_id = cls._MiddlewareCommunicator__registry[fnc.__qualname__]["__WRAPIFY_INSTANCES"].index(instance_address) + 1
+            @wraps(func)
+            def wrapper(*wds, **kwds):  # Triggers on calling the function
+
+                instance_address = hex(id(wds[0]))
+                instance_id = cls._MiddlewareCommunicator__registry[func.__qualname__]["__WRAPIFY_INSTANCES"].index(instance_address) + 1
                 instance_id = "." + str(instance_id) if instance_id > 1 else ""
 
-                kwd = get_default_args(fnc)
+                kwd = get_default_args(func)
                 kwd.update(kwds)
-                cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["args"] = wds
-                cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["kwargs"] = kwd
+                cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["args"] = wds
+                cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["kwargs"] = kwd
 
                 # execute the function as usual
-                if cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["mode"] is None:
-                    return fnc(*wds, **kwds)
+                if cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["mode"] is None:
+                    return func(*wds, **kwds)
 
                 # publishes the functions returns
-                elif cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["mode"] == "publish":
-                    if "wrapped_executor" not in cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"][0]:
-                        cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"].reverse()
+                elif cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["mode"] == "publish":
+                    if "wrapped_executor" not in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"][0]:
+                        cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"].reverse()
                         # instantiate the publishers
-                        for communicator in cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"]:
+                        for communicator in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"]:
                             # single element
                             if isinstance(communicator["return_func_type"], str):
                                 new_args, new_kwargs = match_args(
@@ -95,9 +98,9 @@ class MiddlewareCommunicator(object):
                                     new_args, new_kwargs = match_args(
                                         communicator["return_func_args"][comm_idx], communicator["return_func_kwargs"][comm_idx], wds[1:], kwd)
                                     communicator["wrapped_executor"].append(communicator["return_func_publish"][comm_idx](*new_args, **new_kwargs))
-                    returns = fnc(*wds, **kwds)
+                    returns = func(*wds, **kwds)
                     for ret_idx, ret in enumerate(returns):
-                        wrp_exec = cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"][ret_idx]["wrapped_executor"]
+                        wrp_exec = cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"][ret_idx]["wrapped_executor"]
                         # single element
                         if isinstance(wrp_exec, pub.Publisher):
                             wrp_exec.publish(ret)
@@ -108,11 +111,11 @@ class MiddlewareCommunicator(object):
                     return returns
 
                 # listens to the publisher and returns the messages
-                elif cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["mode"] == "listen":
-                    if "wrapped_executor" not in cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"][0]:
-                        cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"].reverse()
+                elif cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["mode"] == "listen":
+                    if "wrapped_executor" not in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"][0]:
+                        cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"].reverse()
                         # instantiate the listeners
-                        for communicator in cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"]:
+                        for communicator in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"]:
                             # single element
                             if isinstance(communicator["return_func_type"], str):
                                 new_args, new_kwargs = match_args(communicator["return_func_args"], communicator["return_func_kwargs"], wds[1:], kwd)
@@ -123,56 +126,46 @@ class MiddlewareCommunicator(object):
                                 for comm_idx in range(len(communicator["return_func_type"])):
                                     new_args, new_kwargs = match_args(communicator["return_func_args"][comm_idx], communicator["return_func_kwargs"][comm_idx], wds[1:], kwd)
                                     communicator["wrapped_executor"].append(communicator["return_func_listen"][comm_idx](*new_args, **new_kwargs))
-                    cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"] = []
-                    for ret_idx in range(len(cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"])):
-                        wrp_exec = cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"][ret_idx]["wrapped_executor"]
+                    cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"] = []
+                    for ret_idx in range(len(cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"])):
+                        wrp_exec = cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"][ret_idx]["wrapped_executor"]
                         # single element
                         if isinstance(wrp_exec, lsn.Listener):
-                            cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"].append(wrp_exec.listen())
+                            cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"].append(wrp_exec.listen())
                             # list for single return
                         elif isinstance(wrp_exec, list):
                             ret = []
                             for wrp_idx, wrp in enumerate(wrp_exec):
                                 ret.append(wrp.listen())
-                            cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"].append(ret)
+                            cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"].append(ret)
 
-                    return cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"]
+                    return cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"]
 
                 # WARNING: use with caution. This produces "None" for all the function's returns
-                elif  cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["mode"] == "disable":
-                    cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"] = []
-                    for ret_idx in range(len(cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["communicator"])):
-                        cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"].append(None)
-                    return cls._MiddlewareCommunicator__registry[fnc.__qualname__+instance_id]["last_results"]
+                elif cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["mode"] == "disable":
+                    cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"] = []
+                    for ret_idx in range(len(cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"])):
+                        cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"].append(None)
+                    return cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["last_results"]
 
             return wrapper
         return encapsulate
 
-    def activate_communication(self, fnc_name, mode="publish"):
-        instance_addr = str(self).split(" ")[-1]
-        if self.__class__.__name__+"."+fnc_name in self.__registry:
-            if "__WRAPIFY_INSTANCES" in self.__registry[self.__class__.__name__+"."+fnc_name]:
-                if not instance_addr in self.__registry[self.__class__.__name__+"."+fnc_name]["__WRAPIFY_INSTANCES"]:
-                    self.__registry[self.__class__.__name__ + "." + fnc_name]["__WRAPIFY_INSTANCES"].append(instance_addr)
-                    new_instance = True
-                else:
-                    new_instance = False
+    def activate_communication(self, func, mode):
+        entry = self.__registry.get(func.__qualname__, None)
+        if entry is not None:
+            instance_addr = hex(id(self))
+            wrapify_instances = entry.get("__WRAPIFY_INSTANCES", None)
+            if wrapify_instances is None:
+                entry["__WRAPIFY_INSTANCES"] = [instance_addr]
+                instance_id = 1
             else:
-                self.__registry[self.__class__.__name__ + "." + fnc_name]["__WRAPIFY_INSTANCES"] = [instance_addr]
-                new_instance = True
-            if new_instance:
-                instance_id = len(self.__registry[self.__class__.__name__ + "." + fnc_name]["__WRAPIFY_INSTANCES"])
-                if instance_id > 1:
-                    instance_id = "." + str(instance_id)
-                    self.__registry[self.__class__.__name__ + "." + fnc_name + instance_id] = \
-                        copy.deepcopy(self.__registry[self.__class__.__name__ + "." + fnc_name])
-                else:
-                    instance_id = ""
-            else:
-                instance_id = self.__registry[self.__class__.__name__]["__WRAPIFY_INSTANCES"].index(instance_addr) + 1
-                instance_id = "." + str(instance_id) if instance_id > 1 else ""
-
-            self.__registry[self.__class__.__name__+"."+fnc_name + instance_id]["mode"] = mode
-
-
-
+                try:
+                    instance_id = wrapify_instances.index(instance_addr) + 1
+                except ValueError:
+                    wrapify_instances.append(instance_addr)
+                    instance_id = len(wrapify_instances)
+                    if instance_id > 1:
+                        self.__registry[f"{func.__qualname__}.{instance_id}"] = copy.deepcopy(entry)
+            instance_qualname = f"{func.__qualname__}.{instance_id}" if instance_id > 1 else func.__qualname__
+            self.__registry[instance_qualname]["mode"] = mode

--- a/wrapify/connect/wrapper.py
+++ b/wrapify/connect/wrapper.py
@@ -83,9 +83,8 @@ class MiddlewareCommunicator(object):
                 # publishes the functions returns
                 elif cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["mode"] == "publish":
                     if "wrapped_executor" not in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"][0]:
-                        cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"].reverse()
                         # instantiate the publishers
-                        for communicator in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"]:
+                        for communicator in reversed(cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"]):
                             # single element
                             if isinstance(communicator["return_func_type"], str):
                                 new_args, new_kwargs = match_args(
@@ -113,9 +112,8 @@ class MiddlewareCommunicator(object):
                 # listens to the publisher and returns the messages
                 elif cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["mode"] == "listen":
                     if "wrapped_executor" not in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"][0]:
-                        cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"].reverse()
                         # instantiate the listeners
-                        for communicator in cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"]:
+                        for communicator in reversed(cls._MiddlewareCommunicator__registry[func.__qualname__ + instance_id]["communicator"]):
                             # single element
                             if isinstance(communicator["return_func_type"], str):
                                 new_args, new_kwargs = match_args(communicator["return_func_args"], communicator["return_func_kwargs"], wds[1:], kwd)

--- a/wrapify/listeners/ros.py
+++ b/wrapify/listeners/ros.py
@@ -1,0 +1,54 @@
+import rospy
+
+from wrapify.connect.listeners import Listener, ListenerWatchDog, Listeners
+
+
+@Listeners.register("NativeObject", "ros")
+class ROSNativeObjectListener(Listener):
+
+    def __init__(self, name, in_port, carrier="", should_wait=False, load_torch_device=None):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+        # TODO: Initialise variables (e.g. subscriber = None)
+        ListenerWatchDog().add_listener(self)
+
+    def establish(self):
+        # TODO: Create ROS subscriber
+        self.established = True
+
+    def listen(self):
+        if not self.established:
+            self.establish()
+        # TODO: Ctrl+C-able wait for data (or None) depending on self.should_wait
+        return None
+
+
+@Listeners.register("Image", "ros")
+class ROSImageListener(Listener):
+
+    def __init__(self, name, in_port, carrier="", should_wait=False, width=320, height=240, rgb=True):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+        self.width = width
+        self.height = height
+        self.rgb = rgb
+        ListenerWatchDog().add_listener(self)
+        raise NotImplementedError
+
+
+@Listeners.register("AudioChunk", "ros")
+class ROSAudioChunkListener(Listener):
+
+    def __init__(self, name, in_port, carrier="", should_wait=False, channels=1, rate=44100, chunk=-1):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+        self.channels = channels
+        self.rate = rate
+        self.chunk = chunk
+        ListenerWatchDog().add_listener(self)
+        raise NotImplementedError
+
+
+@Listeners.register("Properties", "ros")
+class ROSPropertiesListener(Listener):
+
+    def __init__(self, name, in_port, **kwargs):
+        super().__init__(name, in_port, **kwargs)
+        raise NotImplementedError

--- a/wrapify/listeners/ros.py
+++ b/wrapify/listeners/ros.py
@@ -1,8 +1,9 @@
-import contextlib
 import json
 import queue
+import numpy as np
 import rospy
 import std_msgs.msg
+import sensor_msgs.msg
 
 from wrapify.connect.listeners import Listener, ListenerWatchDog, Listeners
 from wrapify.middlewares.ros import ROSMiddleware
@@ -23,8 +24,7 @@ class ROSNativeObjectListener(ROSListener):
     def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, load_torch_device=None):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size)
         self._json_object_hook = JsonDecodeHook(torch_device=load_torch_device).object_hook
-        self._subscriber = None
-        self._queue = None
+        self._subscriber = self._queue = None
         ListenerWatchDog().add_listener(self)
 
     def establish(self):
@@ -51,13 +51,44 @@ class ROSNativeObjectListener(ROSListener):
 @Listeners.register("Image", "ros")
 class ROSImageListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, width=320, height=240, rgb=True):
+    def __init__(self, name, in_port, carrier="", should_wait=True, width=-1, height=-1, rgb=True, fp=False):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
         self.width = width
         self.height = height
         self.rgb = rgb
+        self.fp = fp
+        self._subscriber = self._type = self._queue = None
+        if self.fp:
+            self._encoding = '32FC3' if self.rgb else '32FC1'
+        else:
+            self._encoding = 'bgr8' if self.rgb else 'mono8'
         ListenerWatchDog().add_listener(self)
-        raise NotImplementedError
+
+    def establish(self):
+        self._queue = queue.Queue(maxsize=0 if self.queue_size is None or self.queue_size <= 0 else self.queue_size)
+        self._subscriber = rospy.Subscriber(self.in_port, sensor_msgs.msg.Image, callback=self._message_callback)
+        self._type = np.float32 if self.fp else np.uint8
+        self.established = True
+
+    def listen(self):
+        if not self.established:
+            self.establish()
+        try:
+            height, width, encoding, is_bigendian, data = self._queue.get(block=self.should_wait)
+            # TODO: Check height width against expected
+            # TODO: Check encoding against expected
+            # TODO: Check data length against expected
+            # TODO: Convert data to numpy array of required dtype/shape, respecting is_bigendian (required only for fp=true)
+            # TODO: Return numpy image
+            raise NotImplementedError
+        except queue.Empty:
+            return None
+
+    def _message_callback(self, data):
+        try:
+            self._queue.put((data.height, data.width, data.encoding, data.is_bigendian, data.data), block=False)
+        except queue.Full:
+            print(f"Discarding data because listener queue is full: {self.in_port}")
 
 
 @Listeners.register("AudioChunk", "ros")
@@ -68,8 +99,8 @@ class ROSAudioChunkListener(ROSListener):
         self.channels = channels
         self.rate = rate
         self.chunk = chunk
+        raise NotImplementedError  # TODO: Adapt ImageListener implementation for Audio chunk (chunk is expected length of array, channels is width)
         ListenerWatchDog().add_listener(self)
-        raise NotImplementedError
 
 
 @Listeners.register("Properties", "ros")

--- a/wrapify/listeners/ros.py
+++ b/wrapify/listeners/ros.py
@@ -12,8 +12,8 @@ from wrapify.utils import JsonDecodeHook
 
 class ROSListener(Listener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, **kwargs)
         ROSMiddleware.activate()
         self.queue_size = queue_size
 
@@ -21,8 +21,8 @@ class ROSListener(Listener):
 @Listeners.register("NativeObject", "ros")
 class ROSNativeObjectListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, load_torch_device=None):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size)
+    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, load_torch_device=None, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size, **kwargs)
         self._json_object_hook = JsonDecodeHook(torch_device=load_torch_device).object_hook
         self._subscriber = self._queue = None
         ListenerWatchDog().add_listener(self)
@@ -51,8 +51,8 @@ class ROSNativeObjectListener(ROSListener):
 @Listeners.register("Image", "ros")
 class ROSImageListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, width=-1, height=-1, rgb=True, fp=False):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, width=-1, height=-1, rgb=True, fp=False, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size, **kwargs)
         self.width = width
         self.height = height
         self.rgb = rgb
@@ -94,8 +94,8 @@ class ROSImageListener(ROSListener):
 @Listeners.register("AudioChunk", "ros")
 class ROSAudioChunkListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, channels=1, rate=44100, chunk=-1):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, channels=1, rate=44100, chunk=-1, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size, **kwargs)
         self.channels = channels
         self.rate = rate
         self.chunk = chunk

--- a/wrapify/listeners/ros.py
+++ b/wrapify/listeners/ros.py
@@ -1,29 +1,55 @@
+import contextlib
+import json
+import queue
 import rospy
+import std_msgs.msg
 
 from wrapify.connect.listeners import Listener, ListenerWatchDog, Listeners
+from wrapify.middlewares.ros import ROSMiddleware
+from wrapify.utils import JsonDecodeHook
+
+
+class ROSListener(Listener):
+
+    def __init__(self, name, in_port, carrier="", should_wait=False, queue_size=5):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+        ROSMiddleware.activate()
+        self.queue_size = queue_size
 
 
 @Listeners.register("NativeObject", "ros")
-class ROSNativeObjectListener(Listener):
+class ROSNativeObjectListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=False, load_torch_device=None):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
-        # TODO: Initialise variables (e.g. subscriber = None)
+    def __init__(self, name, in_port, carrier="", should_wait=False, queue_size=5, load_torch_device=None):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size)
+        self._json_object_hook = JsonDecodeHook(torch_device=load_torch_device).object_hook
+        self._subscriber = None
+        self._queue = None
         ListenerWatchDog().add_listener(self)
 
     def establish(self):
-        # TODO: Create ROS subscriber
+        self._queue = queue.Queue(maxsize=0 if self.queue_size is None or self.queue_size <= 0 else self.queue_size)
+        self._subscriber = rospy.Subscriber(self.in_port, std_msgs.msg.String, callback=self._message_callback)
         self.established = True
 
     def listen(self):
         if not self.established:
             self.establish()
-        # TODO: Ctrl+C-able wait for data (or None) depending on self.should_wait
-        return None
+        try:
+            obj_str = self._queue.get(block=self.should_wait)
+            return json.loads(obj_str, object_hook=self._json_object_hook)
+        except queue.Empty:
+            return None
+
+    def _message_callback(self, data):
+        try:
+            self._queue.put(data.data, block=False)
+        except queue.Full:
+            print(f"Discarding data because listener queue is full: {self.in_port}")
 
 
 @Listeners.register("Image", "ros")
-class ROSImageListener(Listener):
+class ROSImageListener(ROSListener):
 
     def __init__(self, name, in_port, carrier="", should_wait=False, width=320, height=240, rgb=True):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
@@ -35,7 +61,7 @@ class ROSImageListener(Listener):
 
 
 @Listeners.register("AudioChunk", "ros")
-class ROSAudioChunkListener(Listener):
+class ROSAudioChunkListener(ROSListener):
 
     def __init__(self, name, in_port, carrier="", should_wait=False, channels=1, rate=44100, chunk=-1):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
@@ -47,7 +73,7 @@ class ROSAudioChunkListener(Listener):
 
 
 @Listeners.register("Properties", "ros")
-class ROSPropertiesListener(Listener):
+class ROSPropertiesListener(ROSListener):
 
     def __init__(self, name, in_port, **kwargs):
         super().__init__(name, in_port, **kwargs)

--- a/wrapify/listeners/ros.py
+++ b/wrapify/listeners/ros.py
@@ -11,7 +11,7 @@ from wrapify.utils import JsonDecodeHook
 
 class ROSListener(Listener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=False, queue_size=5):
+    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
         ROSMiddleware.activate()
         self.queue_size = queue_size
@@ -20,7 +20,7 @@ class ROSListener(Listener):
 @Listeners.register("NativeObject", "ros")
 class ROSNativeObjectListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=False, queue_size=5, load_torch_device=None):
+    def __init__(self, name, in_port, carrier="", should_wait=True, queue_size=5, load_torch_device=None):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, queue_size=queue_size)
         self._json_object_hook = JsonDecodeHook(torch_device=load_torch_device).object_hook
         self._subscriber = None
@@ -51,7 +51,7 @@ class ROSNativeObjectListener(ROSListener):
 @Listeners.register("Image", "ros")
 class ROSImageListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=False, width=320, height=240, rgb=True):
+    def __init__(self, name, in_port, carrier="", should_wait=True, width=320, height=240, rgb=True):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
         self.width = width
         self.height = height
@@ -63,7 +63,7 @@ class ROSImageListener(ROSListener):
 @Listeners.register("AudioChunk", "ros")
 class ROSAudioChunkListener(ROSListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=False, channels=1, rate=44100, chunk=-1):
+    def __init__(self, name, in_port, carrier="", should_wait=True, channels=1, rate=44100, chunk=-1):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
         self.channels = channels
         self.rate = rate

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -98,9 +98,10 @@ class YarpImageListener(Listener):
         return self.__listener()
 
     def close(self):
-        self._port.close()
+        if self._port:
+            self._port.close()
 
-    def __del__(self, exc_type, exc_val, exc_tb):
+    def __del__(self):
         self.close()
 
 
@@ -143,7 +144,7 @@ class YarpAudioChunkListener(YarpImageListener):
     def listen(self):
         if not self.established:
             self.establish()
-        return self.__listener(), self.rate
+        return self._YarpImageListener__listener(), self.rate
 
 
 @Listeners.register("NativeObject", "yarp")

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import numpy as np
@@ -10,8 +11,8 @@ except:
     logging.warning("YARP is not found and cannot be used")
     pass
 
-from wrapify.utils import JsonEncoder as json
 from wrapify.connect.listeners import Listener, ListenerWatchDog, Listeners
+import wrapify.utils
 
 
 @Listeners.register("Image", "yarp")
@@ -152,6 +153,7 @@ class YarpNativeObjectListener(Listener):
     def __init__(self, name, in_port, carrier="", should_wait=False):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
 
+        self._json_object_hook = wrapify.utils.JsonDecodeHook().object_hook
         self._port, self.__netconnect = [None] * 2
         ListenerWatchDog().add_listener(self)
 
@@ -173,7 +175,7 @@ class YarpNativeObjectListener(Listener):
         obj = self._port.read(shouldWait=self.should_wait)
         if obj is not None:
             iobj = obj.get(0).asString()
-            iobj = json.loads(iobj)
+            iobj = json.loads(iobj, object_hook=self._json_object_hook)
         else:
             iobj = None
         return iobj

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -150,10 +150,10 @@ class YarpAudioChunkListener(YarpImageListener):
 
 @Listeners.register("NativeObject", "yarp")
 class YarpNativeObjectListener(Listener):
-    def __init__(self, name, in_port, carrier="", should_wait=False):
+    def __init__(self, name, in_port, carrier="", should_wait=False, load_torch_device=None):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
 
-        self._json_object_hook = wrapify.utils.JsonDecodeHook().object_hook
+        self._json_object_hook = wrapify.utils.JsonDecodeHook(torch_device=load_torch_device).object_hook
         self._port, self.__netconnect = [None] * 2
         ListenerWatchDog().add_listener(self)
 

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -176,12 +176,7 @@ class YarpNativeObjectListener(YarpListener):
                 time.sleep(0.005)
             else:
                 break
-        if obj is not None:
-            iobj = obj.get(0).asString()
-            iobj = json.loads(iobj, object_hook=self._json_object_hook)
-        else:
-            iobj = None
-        return iobj
+        return json.loads(obj.get(0).asString(), object_hook=self._json_object_hook) if obj is not None else None
 
 
 @Listeners.register("Properties", "yarp")

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -51,17 +51,17 @@ class YarpImageListener(YarpListener):
 
         # set the listener
         if self.width == -1 and self.height == -1:
-            self._listener = self.__listen_unk_width_height
+            self._listener = self._listen_unk_width_height
         elif self.width == -1:
-            self._listener = self.__listen_unk_width
+            self._listener = self._listen_unk_width
         elif self.height == -1:
-            self._listener = self.__listen_unk_height
+            self._listener = self._listen_unk_height
         else:
-            self._listener = self.__listen
+            self._listener = self._listen
 
         self.established = True
 
-    def __listen_unk_width(self):
+    def _listen_unk_width(self):
         # TODO (fabawi): dynamic width only
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
@@ -70,7 +70,7 @@ class YarpImageListener(YarpListener):
                             img.width(), img.height())
         return self._iarray
 
-    def __listen_unk_height(self):
+    def _listen_unk_height(self):
         # TODO (fabawi): dynamic height only
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
@@ -79,7 +79,7 @@ class YarpImageListener(YarpListener):
                             img.width(), img.height())
         return self._iarray
 
-    def __listen_unk_width_height(self):
+    def _listen_unk_width_height(self):
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
             self._iarray = np.zeros((img.height(), img.width()), dtype=self._type)
@@ -87,7 +87,7 @@ class YarpImageListener(YarpListener):
                             img.width(), img.height())
         return self._iarray
 
-    def __listen(self):
+    def _listen(self):
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
             img.setExternal(self._iarray.data, self._iarray.shape[1], self._iarray.shape[0])

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -10,55 +10,54 @@ from wrapify.utils import JsonDecodeHook
 
 class YarpListener(Listener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=False):
+    def __init__(self, name, in_port, carrier="", should_wait=True):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
         YarpMiddleware.activate()
 
 
 @Listeners.register("Image", "yarp")
 class YarpImageListener(YarpListener):
-    def __init__(self, name, in_port, carrier="", should_wait=False, width=320, height=240, rgb=True):
+    def __init__(self, name, in_port, carrier="", should_wait=True, width=320, height=240, rgb=True):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
         self.width = width
         self.height = height
         self.rgb = rgb
-
-        self._port, self._iarray, self.__netconnect, self.__type, self.__listener = [None] * 5
+        self._port = self._iarray = self._netconnect = self._type = self._listener = None
         ListenerWatchDog().add_listener(self)
 
     def establish(self):
-        print("waiting for in_port: ", self.in_port)
+        print("Waiting for input port:", self.in_port)
         while not yarp.Network.exists(self.in_port):
-            yarp.Network.waitPort(self.in_port, quiet=True)
-        print("connected to in_port: ", self.in_port)
+            time.sleep(0.2)
+        print("Connected to input port:", self.in_port)
         if self.rgb:
             self._port = yarp.BufferedPortImageRgb()
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._port.open(self.in_port + ":in" + rnd_id)
             self._port.setStrict()
-            self.__netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
+            self._netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
             if self.height != -1 and self.width != -1:
                 self._iarray = np.zeros((self.height, self.width, 3), dtype=np.uint8)
-            self.__type = np.uint8
+            self._type = np.uint8
         else:
             self._port = yarp.BufferedPortImageFloat()
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._port.open(self.in_port + ":in" + rnd_id)
             self._port.setStrict()
-            self.__netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
+            self._netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
             if self.height != -1 and self.width != -1:
                 self._iarray = np.zeros((self.height, self.width), dtype=np.float32)
-            self.__type = np.float32
+            self._type = np.float32
 
         # set the listener
         if self.width == -1 and self.height == -1:
-            self.__listener = self.__listen_unk_width_height
+            self._listener = self.__listen_unk_width_height
         elif self.width == -1:
-            self.__listener = self.__listen_unk_width
+            self._listener = self.__listen_unk_width
         elif self.height == -1:
-            self.__listener = self.__listen_unk_height
+            self._listener = self.__listen_unk_height
         else:
-            self.__listener = self.__listen
+            self._listener = self.__listen
 
         self.established = True
 
@@ -66,7 +65,7 @@ class YarpImageListener(YarpListener):
         # TODO (fabawi): dynamic width only
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
-            self._iarray = np.zeros((img.height(), img.width()), dtype=self.__type)
+            self._iarray = np.zeros((img.height(), img.width()), dtype=self._type)
             img.setExternal(self._iarray.data,
                             img.width(), img.height())
         return self._iarray
@@ -75,7 +74,7 @@ class YarpImageListener(YarpListener):
         # TODO (fabawi): dynamic height only
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
-            self._iarray = np.zeros((img.height(), img.width()), dtype=self.__type)
+            self._iarray = np.zeros((img.height(), img.width()), dtype=self._type)
             img.setExternal(self._iarray.data,
                             img.width(), img.height())
         return self._iarray
@@ -83,7 +82,7 @@ class YarpImageListener(YarpListener):
     def __listen_unk_width_height(self):
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
-            self._iarray = np.zeros((img.height(), img.width()), dtype=self.__type)
+            self._iarray = np.zeros((img.height(), img.width()), dtype=self._type)
             img.setExternal(self._iarray.data,
                             img.width(), img.height())
         return self._iarray
@@ -91,14 +90,13 @@ class YarpImageListener(YarpListener):
     def __listen(self):
         img = self._port.read(shouldWait=self.should_wait)
         if img is not None:
-            img.setExternal(self._iarray.data,
-                        self._iarray.shape[1], self._iarray.shape[0])
+            img.setExternal(self._iarray.data, self._iarray.shape[1], self._iarray.shape[0])
         return self._iarray
 
     def listen(self):
         if not self.established:
             self.establish()
-        return self.__listener()
+        return self._listener()
 
     def close(self):
         if self._port:
@@ -110,30 +108,28 @@ class YarpImageListener(YarpListener):
 
 @Listeners.register("AudioChunk", "yarp")
 class YarpAudioChunkListener(YarpImageListener):
-    def __init__(self, name, in_port, carrier="", should_wait=False, channels=1, rate=44100, chunk=-1):
+    def __init__(self, name, in_port, carrier="", should_wait=True, channels=1, rate=44100, chunk=-1):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait,
                          width=chunk, height=channels, rgb=False)
         self.channels = channels
         self.rate = rate
         self.chunk = chunk
 
-        self._dummy_sound, self._dummy_port, self.__dummy_netconnect = [None] * 3
+        self._dummy_sound = self._dummy_port = self._dummy_netconnect = None
         ListenerWatchDog().add_listener(self)
 
     def establish(self):
-        print("waiting for in_port: ", self.in_port + "_SND")
+        print("Waiting for input port:", self.in_port + "_SND")
         while not yarp.Network.exists(self.in_port + "_SND"):
-            yarp.Network.waitPort(self.in_port, quiet=True)
-        print("connected to in_port: ", self.in_port + "_SND")
+            time.sleep(0.2)
+        print("Connected to input port:", self.in_port + "_SND")
 
         if self.channels == -1 or self.rate == -1 or self.chunk == -1:
             # create a dummy sound object for transmitting the sound props. This could be cleaner but left for future impl.
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._dummy_port = yarp.Port()
             self._dummy_port.open(self.in_port + "_SND:in" + rnd_id)
-            self.__dummy_netconnect = yarp.Network.connect(self.in_port + "_SND",
-                                                             self.in_port + "_SND:in" + rnd_id,
-                                                             self.carrier)
+            self._dummy_netconnect = yarp.Network.connect(self.in_port + "_SND", self.in_port + "_SND:in" + rnd_id, self.carrier)
             self._dummy_sound = yarp.Sound()
             self.rate = self._dummy_sound.getFrequency()
             self.chunk = self._dummy_sound.getSamples()
@@ -147,29 +143,28 @@ class YarpAudioChunkListener(YarpImageListener):
     def listen(self):
         if not self.established:
             self.establish()
-        return self._YarpImageListener__listener(), self.rate
+        return self._listener(), self.rate
 
 
 @Listeners.register("NativeObject", "yarp")
 class YarpNativeObjectListener(YarpListener):
-    def __init__(self, name, in_port, carrier="", should_wait=False, load_torch_device=None):
+    def __init__(self, name, in_port, carrier="", should_wait=True, load_torch_device=None):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
 
         self._json_object_hook = JsonDecodeHook(torch_device=load_torch_device).object_hook
-        self._port, self.__netconnect = [None] * 2
+        self._port = self._netconnect = None
         ListenerWatchDog().add_listener(self)
 
     def establish(self):
         print("Waiting for input port:", self.in_port)
         while not yarp.Network.exists(self.in_port):
-            yarp.Network.waitPort(self.in_port, quiet=True)
+            time.sleep(0.2)
         print("Connected to input port:", self.in_port)
         self._port = yarp.BufferedPortBottle()
         rnd_id = str(np.random.randint(100000, size=1)[0])
         self._port.open(self.in_port + ":in" + rnd_id)
         self._port.setStrict()
-        self.__netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
-
+        self._netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
         self.established = True
 
     def listen(self):

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -35,6 +35,7 @@ class YarpImageListener(YarpListener):
             self._port = yarp.BufferedPortImageRgb()
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._port.open(self.in_port + ":in" + rnd_id)
+            self._port.setStrict()
             self.__netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
             if self.height != -1 and self.width != -1:
                 self._iarray = np.zeros((self.height, self.width, 3), dtype=np.uint8)
@@ -43,6 +44,7 @@ class YarpImageListener(YarpListener):
             self._port = yarp.BufferedPortImageFloat()
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._port.open(self.in_port + ":in" + rnd_id)
+            self._port.setStrict()
             self.__netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
             if self.height != -1 and self.width != -1:
                 self._iarray = np.zeros((self.height, self.width), dtype=np.float32)
@@ -165,6 +167,7 @@ class YarpNativeObjectListener(YarpListener):
         self._port = yarp.BufferedPortBottle()
         rnd_id = str(np.random.randint(100000, size=1)[0])
         self._port.open(self.in_port + ":in" + rnd_id)
+        self._port.setStrict()
         self.__netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
 
         self.established = True

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -104,7 +104,7 @@ class YarpImageListener(Listener):
 
 @Listeners.register("AudioChunk", "yarp")
 class YarpAudioChunkListener(YarpImageListener):
-    def __init__(self, name, in_port, carrier="", should_wait=False, channels=1, rate=44100, chunk=44100):
+    def __init__(self, name, in_port, carrier="", should_wait=False, channels=1, rate=44100, chunk=-1):
         super().__init__(name, in_port, carrier=carrier, should_wait=should_wait,
                          width=chunk, height=channels, rgb=False)
         self.channels = channels

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -160,10 +160,10 @@ class YarpNativeObjectListener(YarpListener):
         ListenerWatchDog().add_listener(self)
 
     def establish(self):
-        print("waiting for in_port: ", self.in_port)
+        print("Waiting for input port:", self.in_port)
         while not yarp.Network.exists(self.in_port):
             yarp.Network.waitPort(self.in_port, quiet=True)
-        print("connected to in_port: ", self.in_port)
+        print("Connected to input port:", self.in_port)
         self._port = yarp.BufferedPortBottle()
         rnd_id = str(np.random.randint(100000, size=1)[0])
         self._port.open(self.in_port + ":in" + rnd_id)

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -10,8 +10,8 @@ from wrapify.utils import JsonDecodeHook
 
 class YarpListener(Listener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+    def __init__(self, name, in_port, carrier="", should_wait=True, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, **kwargs)
         YarpMiddleware.activate()
 
     def await_connection(self, port=None):
@@ -34,8 +34,8 @@ class YarpListener(Listener):
 @Listeners.register("NativeObject", "yarp")
 class YarpNativeObjectListener(YarpListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, load_torch_device=None):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+    def __init__(self, name, in_port, carrier="", should_wait=True, load_torch_device=None, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, **kwargs)
         self._json_object_hook = JsonDecodeHook(torch_device=load_torch_device).object_hook
         self._port = self._netconnect = None
         ListenerWatchDog().add_listener(self)
@@ -61,8 +61,8 @@ class YarpNativeObjectListener(YarpListener):
 @Listeners.register("Image", "yarp")
 class YarpImageListener(YarpListener):
 
-    def __init__(self, name, in_port, carrier="", should_wait=True, width=-1, height=-1, rgb=True, fp=False):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait)
+    def __init__(self, name, in_port, carrier="", should_wait=True, width=-1, height=-1, rgb=True, fp=False, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, **kwargs)
         self.width = width
         self.height = height
         self.rgb = rgb
@@ -111,8 +111,8 @@ class YarpImageListener(YarpListener):
 
 @Listeners.register("AudioChunk", "yarp")
 class YarpAudioChunkListener(YarpImageListener):
-    def __init__(self, name, in_port, carrier="", should_wait=True, channels=1, rate=44100, chunk=-1):
-        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, width=chunk, height=channels, rgb=False, fp=True)
+    def __init__(self, name, in_port, carrier="", should_wait=True, channels=1, rate=44100, chunk=-1, **kwargs):
+        super().__init__(name, in_port, carrier=carrier, should_wait=should_wait, width=chunk, height=channels, rgb=False, fp=True, **kwargs)
         self.channels = channels
         self.rate = rate
         self.chunk = chunk
@@ -143,6 +143,7 @@ class YarpAudioChunkListener(YarpImageListener):
 
 @Listeners.register("Properties", "yarp")
 class YarpPropertiesListener(YarpListener):
+
     def __init__(self, name, in_port, **kwargs):
         super().__init__(name, in_port, **kwargs)
         raise NotImplementedError

--- a/wrapify/listeners/yarp.py
+++ b/wrapify/listeners/yarp.py
@@ -34,7 +34,6 @@ class YarpImageListener(YarpListener):
             self._port = yarp.BufferedPortImageRgb()
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._port.open(self.in_port + ":in" + rnd_id)
-            self._port.setStrict()
             self._netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
             if self.height != -1 and self.width != -1:
                 self._iarray = np.zeros((self.height, self.width, 3), dtype=np.uint8)
@@ -43,7 +42,6 @@ class YarpImageListener(YarpListener):
             self._port = yarp.BufferedPortImageFloat()
             rnd_id = str(np.random.randint(100000, size=1)[0])
             self._port.open(self.in_port + ":in" + rnd_id)
-            self._port.setStrict()
             self._netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
             if self.height != -1 and self.width != -1:
                 self._iarray = np.zeros((self.height, self.width), dtype=np.float32)
@@ -163,7 +161,6 @@ class YarpNativeObjectListener(YarpListener):
         self._port = yarp.BufferedPortBottle()
         rnd_id = str(np.random.randint(100000, size=1)[0])
         self._port.open(self.in_port + ":in" + rnd_id)
-        self._port.setStrict()
         self._netconnect = yarp.Network.connect(self.in_port, self.in_port + ":in" + rnd_id, self.carrier)
         self.established = True
 

--- a/wrapify/middlewares/ros.py
+++ b/wrapify/middlewares/ros.py
@@ -1,0 +1,21 @@
+import atexit
+import rospy
+
+from wrapify.utils import SingletonOptimized
+
+
+class ROSMiddleware(metaclass=SingletonOptimized):
+
+    @staticmethod
+    def activate():
+        ROSMiddleware()
+
+    def __init__(self):
+        print("Initialising ROS middleware")
+        rospy.init_node('wrapify', anonymous=True, disable_signals=True)
+        atexit.register(self.deinit)
+
+    @staticmethod
+    def deinit():
+        print("Deinitialising ROS middleware")
+        rospy.signal_shutdown('Deinit')

--- a/wrapify/middlewares/yarp.py
+++ b/wrapify/middlewares/yarp.py
@@ -1,0 +1,21 @@
+import atexit
+import yarp
+
+from wrapify.utils import SingletonOptimized
+
+
+class YarpMiddleware(metaclass=SingletonOptimized):
+
+    @staticmethod
+    def activate():
+        YarpMiddleware()
+
+    def __init__(self):
+        print("Initialising YARP middleware")
+        yarp.Network.init()
+        atexit.register(self.deinit)
+
+    @staticmethod
+    def deinit():
+        print("Deinitialising YARP middleware")
+        yarp.Network.fini()

--- a/wrapify/publishers/ros.py
+++ b/wrapify/publishers/ros.py
@@ -56,16 +56,17 @@ class ROSImagePublisher(ROSPublisher):
         self.height = height
         self.rgb = rgb
         self.fp = fp
-        self._publisher = self._type = None
         if self.fp:
             self._encoding = '32FC3' if self.rgb else '32FC1'
+            self._type = np.float32
         else:
             self._encoding = 'bgr8' if self.rgb else 'mono8'
+            self._type = np.uint8
+        self._publisher = None
         PublisherWatchDog().add_publisher(self)
 
     def establish(self):
         self._publisher = rospy.Publisher(self.out_port, sensor_msgs.msg.Image, queue_size=self.queue_size)
-        self._type = np.float32 if self.fp else np.uint8
         self.await_connection(self._publisher)
         self.established = True
 

--- a/wrapify/publishers/ros.py
+++ b/wrapify/publishers/ros.py
@@ -1,7 +1,10 @@
+import sys
 import json
 import time
+import numpy as np
 import rospy
 import std_msgs.msg
+import sensor_msgs.msg
 
 from wrapify.connect.publishers import Publisher, Publishers, PublisherWatchDog
 from wrapify.middlewares.ros import ROSMiddleware
@@ -47,25 +50,78 @@ class ROSNativeObjectPublisher(ROSPublisher):
 @Publishers.register("Image", "ros")
 class ROSImagePublisher(ROSPublisher):
 
-    def __init__(self, name, out_port, carrier="", out_port_connect=None, width=320, height=240, rgb=True, **kwargs):
-        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, width=-1, height=-1, rgb=True, fp=False, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect, **kwargs)
         self.width = width
         self.height = height
         self.rgb = rgb
+        self.fp = fp
+        self._publisher = self._type = None
+        if self.fp:
+            self._encoding = '32FC3' if self.rgb else '32FC1'
+        else:
+            self._encoding = 'bgr8' if self.rgb else 'mono8'
         PublisherWatchDog().add_publisher(self)
-        raise NotImplementedError
+
+    def establish(self):
+        self._publisher = rospy.Publisher(self.out_port, sensor_msgs.msg.Image, queue_size=self.queue_size)
+        self._type = np.float32 if self.fp else np.uint8
+        self.await_connection(self._publisher)
+        self.established = True
+
+    def publish(self, img):
+        if not self.established:
+            self.establish()
+        if 0 < self.width != img.shape[1] or 0 < self.height != img.shape[0] or not ((img.ndim == 2 and not self.rgb) or (img.ndim == 3 and self.rgb and img.shape[2] == 3)):
+            raise ValueError("Incorrect image shape for publisher")
+        img = np.require(img, dtype=self._type, requirements='C')
+        msg = sensor_msgs.msg.Image()
+        msg.header.stamp = rospy.Time.now()
+        msg.height = img.shape[0]
+        msg.width = img.shape[1]
+        msg.encoding = self._encoding
+        msg.is_bigendian = img.dtype.byteorder == '>' or (img.dtype.byteorder == '=' and sys.byteorder == 'big')
+        msg.step = img.strides[0]
+        msg.data = img.tobytes()
+        self._publisher.publish(msg)
 
 
 @Publishers.register("AudioChunk", "ros")
 class ROSAudioChunkPublisher(ROSPublisher):
 
     def __init__(self, name, out_port, carrier="", out_port_connect=None, channels=1, rate=44100, chunk=-1, **kwargs):
-        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect, **kwargs)
         self.channels = channels
         self.rate = rate
         self.chunk = chunk
+        self._publisher = None
         PublisherWatchDog().add_publisher(self)
-        raise NotImplementedError
+
+    def establish(self, **kwargs):
+        self._publisher = rospy.Publisher(self.out_port, sensor_msgs.msg.Image, queue_size=self.queue_size)
+        self.await_connection(self._publisher)
+        self.established = True
+
+    def publish(self, aud):
+        if not self.established:
+            self.establish()
+        aud, rate = aud
+        if rate != self.rate:
+            raise ValueError("Incorrect audio rate for publisher")
+        if aud is None:
+            return
+        if 0 < self.chunk != aud.shape[0] or aud.shape[1] != self.channels:
+            raise ValueError("Incorrect audio shape for publisher")
+        aud = np.require(aud, dtype=np.float32, requirements='C')
+        msg = sensor_msgs.msg.Image()
+        msg.header.stamp = rospy.Time.now()
+        msg.height = aud.shape[0]
+        msg.width = aud.shape[1]
+        msg.encoding = '32FC1'
+        msg.is_bigendian = aud.dtype.byteorder == '>' or (aud.dtype.byteorder == '=' and sys.byteorder == 'big')
+        msg.step = aud.strides[0]
+        msg.data = aud.tobytes()
+        self._publisher.publish(msg)
 
 
 @Publishers.register("Properties", "ros")

--- a/wrapify/publishers/ros.py
+++ b/wrapify/publishers/ros.py
@@ -1,0 +1,53 @@
+import rospy
+
+from wrapify.connect.publishers import Publisher, Publishers, PublisherWatchDog
+
+
+@Publishers.register("NativeObject", "ros")
+class ROSNativeObjectPublisher(Publisher):
+
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
+        # TODO: Initialise variables (e.g. publisher = None)
+        PublisherWatchDog().add_publisher(self)
+
+    def establish(self):
+        # TODO: Create ROS publisher
+        self.established = True
+
+    def publish(self, obj):
+        if not self.established:
+            self.establish()
+        # TODO: Publish obj to topic
+
+
+@Publishers.register("Image", "ros")
+class ROSImagePublisher(Publisher):
+
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, width=320, height=240, rgb=True, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
+        self.width = width
+        self.height = height
+        self.rgb = rgb
+        PublisherWatchDog().add_publisher(self)
+        raise NotImplementedError
+
+
+@Publishers.register("AudioChunk", "ros")
+class ROSAudioChunkPublisher(Publisher):
+
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, channels=1, rate=44100, chunk=-1, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
+        self.channels = channels
+        self.rate = rate
+        self.chunk = chunk
+        PublisherWatchDog().add_publisher(self)
+        raise NotImplementedError
+
+
+@Publishers.register("Properties", "ros")
+class ROSPropertiesPublisher(Publisher):
+
+    def __init__(self, name, out_port, **kwargs):
+        super().__init__(name, out_port, **kwargs)
+        raise NotImplementedError

--- a/wrapify/publishers/ros.py
+++ b/wrapify/publishers/ros.py
@@ -1,28 +1,41 @@
+import json
 import rospy
+import std_msgs.msg
 
 from wrapify.connect.publishers import Publisher, Publishers, PublisherWatchDog
+from wrapify.middlewares.ros import ROSMiddleware
+from wrapify.utils import JsonEncoder
+
+
+class ROSPublisher(Publisher):
+
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, queue_size=5, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect, **kwargs)
+        ROSMiddleware.activate()
+        self.queue_size = queue_size
 
 
 @Publishers.register("NativeObject", "ros")
-class ROSNativeObjectPublisher(Publisher):
+class ROSNativeObjectPublisher(ROSPublisher):
 
-    def __init__(self, name, out_port, carrier="", out_port_connect=None, **kwargs):
-        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
-        # TODO: Initialise variables (e.g. publisher = None)
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, queue_size=5, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect, queue_size=queue_size, **kwargs)
+        self._publisher = None
         PublisherWatchDog().add_publisher(self)
 
     def establish(self):
-        # TODO: Create ROS publisher
+        self._publisher = rospy.Publisher(self.out_port, std_msgs.msg.String, queue_size=self.queue_size)
         self.established = True
 
     def publish(self, obj):
         if not self.established:
             self.establish()
-        # TODO: Publish obj to topic
+        obj_str = json.dumps(obj, cls=JsonEncoder)
+        self._publisher.publish(obj_str)
 
 
 @Publishers.register("Image", "ros")
-class ROSImagePublisher(Publisher):
+class ROSImagePublisher(ROSPublisher):
 
     def __init__(self, name, out_port, carrier="", out_port_connect=None, width=320, height=240, rgb=True, **kwargs):
         super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
@@ -34,7 +47,7 @@ class ROSImagePublisher(Publisher):
 
 
 @Publishers.register("AudioChunk", "ros")
-class ROSAudioChunkPublisher(Publisher):
+class ROSAudioChunkPublisher(ROSPublisher):
 
     def __init__(self, name, out_port, carrier="", out_port_connect=None, channels=1, rate=44100, chunk=-1, **kwargs):
         super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
@@ -46,7 +59,7 @@ class ROSAudioChunkPublisher(Publisher):
 
 
 @Publishers.register("Properties", "ros")
-class ROSPropertiesPublisher(Publisher):
+class ROSPropertiesPublisher(ROSPublisher):
 
     def __init__(self, name, out_port, **kwargs):
         super().__init__(name, out_port, **kwargs)

--- a/wrapify/publishers/ros.py
+++ b/wrapify/publishers/ros.py
@@ -1,4 +1,5 @@
 import json
+import time
 import rospy
 import std_msgs.msg
 
@@ -14,6 +15,14 @@ class ROSPublisher(Publisher):
         ROSMiddleware.activate()
         self.queue_size = queue_size
 
+    def await_connection(self, publisher, out_port=None):
+        if out_port is None:
+            out_port = self.out_port
+        print("Waiting for topic subscriber:", out_port)
+        while publisher.get_num_connections() < 1:
+            time.sleep(0.02)
+        print("Topic subscriber connected:", out_port)
+
 
 @Publishers.register("NativeObject", "ros")
 class ROSNativeObjectPublisher(ROSPublisher):
@@ -25,6 +34,7 @@ class ROSNativeObjectPublisher(ROSPublisher):
 
     def establish(self):
         self._publisher = rospy.Publisher(self.out_port, std_msgs.msg.String, queue_size=self.queue_size)
+        self.await_connection(self._publisher)
         self.established = True
 
     def publish(self, obj):

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -163,7 +163,6 @@ class YarpNativeObjectPublisher(Publisher):
         oobj = self._port.prepare()
         oobj.clear()
         oobj.addString(obj)
-        # print(oobj.get(0).asString())
         self._port.write()
 
 

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -1,17 +1,21 @@
 import json
-import atexit
 import cv2
 import yarp
 
 from wrapify.connect.publishers import Publisher, Publishers, PublisherWatchDog
+from wrapify.middlewares.yarp import YarpMiddleware
 from wrapify.utils import JsonEncoder
 
-yarp.Network.init()
-atexit.register(yarp.Network.fini)
+
+class YarpPublisher(Publisher):
+
+    def __init__(self, name, out_port, carrier="", out_port_connect=None, **kwargs):
+        super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect, **kwargs)
+        YarpMiddleware.activate()
 
 
 @Publishers.register("Image", "yarp")
-class YarpImagePublisher(Publisher):
+class YarpImagePublisher(YarpPublisher):
     """
     The ImagePublisher using the BufferedPortImage construct assuming a cv2 image as an input
     """
@@ -126,7 +130,7 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
 
 
 @Publishers.register("NativeObject", "yarp")
-class YarpNativeObjectPublisher(Publisher):
+class YarpNativeObjectPublisher(YarpPublisher):
     """
         The NativeObjectPublisher using the BufferedPortBottle construct assuming a combination of python native objects
         and numpy arrays as input
@@ -162,7 +166,7 @@ class YarpNativeObjectPublisher(Publisher):
 
 
 @Publishers.register("Properties", "yarp")
-class YarpPropertiesPublisher(Publisher):
+class YarpPropertiesPublisher(YarpPublisher):
     def __init__(self, name, out_port, **kwargs):
         super().__init__(name, out_port, **kwargs)
         raise NotImplementedError

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -141,7 +141,6 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
         self.channels = channels
         self.rate = rate
         self.chunk = chunk
-
         self._dummy_sound = self._dummy_port = self._dummy_netconnect = None
         PublisherWatchDog().add_publisher(self)
 
@@ -155,6 +154,7 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
         self._dummy_sound.resize(self.chunk, self.channels)
         self.await_connection(self._dummy_port, out_port=self.out_port + "_SND")
         super(YarpAudioChunkPublisher, self).establish()
+        self._dummy_port.write(self._dummy_sound)
 
     def publish(self, aud):
         """
@@ -169,7 +169,11 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
             oaud = self._port.prepare()
             oaud.setExternal(aud.data, self.chunk if self.chunk != -1 else oaud.shape[1], self.channels)
             self._port.write()
-            self._dummy_port.write(self._dummy_sound)
+
+    def close(self):
+        super().close()
+        if self._dummy_port:
+            self._dummy_port.close()
 
 
 @Publishers.register("Properties", "yarp")

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -43,19 +43,18 @@ class YarpImagePublisher(YarpPublisher):
         self.width = width
         self.height = height
         self.rgb = rgb
-
-        self._port, self.__netconnect = [None] * 2
+        self._port = self._netconnect = None
         PublisherWatchDog().add_publisher(self)
 
     def establish(self):
         if self.rgb:
             self._port = yarp.BufferedPortImageRgb()
             self._port.open(self.out_port)
-            self.__netconnect = yarp.Network.connect(self.out_port, self.out_port_connect, self.carrier)
+            self._netconnect = yarp.Network.connect(self.out_port, self.out_port_connect, self.carrier)
         else:
             self._port = yarp.BufferedPortImageFloat()
             self._port.open(self.out_port)
-            self.__netconnect = yarp.Network.connect(self.out_port, self.out_port_connect, self.carrier)
+            self._netconnect = yarp.Network.connect(self.out_port, self.out_port_connect, self.carrier)
         self.await_connection(self._port)
         self.established = True
 
@@ -107,14 +106,14 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
         self.rate = rate
         self.chunk = chunk
 
-        self._dummy_sound, self._dummy_port, self.__dummy_netconnect = [None] * 3
+        self._dummy_sound = self._dummy_port = self._dummy_netconnect = None
         PublisherWatchDog().add_publisher(self)
 
     def establish(self):
         # create a dummy sound object for transmitting the sound props. This could be cleaner but left for future impl.
         self._dummy_port = yarp.Port()
         self._dummy_port.open(self.out_port + "_SND")
-        self.__dummy_netconnect = yarp.Network.connect(self.out_port + "_SND", self.out_port_connect + "_SND", self.carrier)
+        self._dummy_netconnect = yarp.Network.connect(self.out_port + "_SND", self.out_port_connect + "_SND", self.carrier)
         self._dummy_sound = yarp.Sound()
         self._dummy_sound.setFrequency(self.rate)
         self._dummy_sound.resize(self.chunk, self.channels)
@@ -152,14 +151,13 @@ class YarpNativeObjectPublisher(YarpPublisher):
         :param out_port_connect: This is an optional port connection for listening devices (follows out_port format)
         """
         super().__init__(name, out_port, carrier=carrier, out_port_connect=out_port_connect)
-
-        self._port, self.__netconnect = [None] * 2
+        self._port = self._netconnect = None
         PublisherWatchDog().add_publisher(self)
 
     def establish(self):
         self._port = yarp.BufferedPortBottle()
         self._port.open(self.out_port)
-        self.__netconnect = yarp.Network.connect(self.out_port, self.out_port_connect, self.carrier)
+        self._netconnect = yarp.Network.connect(self.out_port, self.out_port_connect, self.carrier)
         self.await_connection(self._port)
         self.established = True
 

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -1,18 +1,13 @@
 import json
-import logging
+import atexit
 import cv2
-
-try:
-    import yarp
-    yarp.Network.init()
-    logging.info("YARP is found and can be used")
-except:
-    # print("Install YARP to use wrapify")
-    logging.warning("YARP is not found and cannot be used")
-    pass
+import yarp
 
 from wrapify.connect.publishers import Publisher, Publishers, PublisherWatchDog
 from wrapify.utils import JsonEncoder
+
+yarp.Network.init()
+atexit.register(yarp.Network.fini)
 
 
 @Publishers.register("Image", "yarp")

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -70,9 +70,10 @@ class YarpImagePublisher(Publisher):
         Close the port
         :return: None
         """
-        self._port.close()
+        if self._port:
+            self._port.close()
 
-    def __del__(self, exc_type, exc_val, exc_tb):
+    def __del__(self):
         self.close()
 
 

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -61,7 +61,7 @@ class YarpImagePublisher(YarpPublisher):
         img = cv2.resize(img, dsize=(self.width, self.height), interpolation=cv2.INTER_CUBIC)
         oimg = self._port.prepare()
         oimg.setExternal(img.data, img.shape[1], img.shape[0])
-        self._port.write()
+        self._port.write(forceStrict=True)
 
     def close(self):
         """
@@ -125,7 +125,7 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
         if aud is not None:
             oaud = self._port.prepare()
             oaud.setExternal(aud.data, self.chunk if self.chunk != -1 else oaud.shape[1], self.channels)
-            self._port.write()
+            self._port.write(forceStrict=True)
             self._dummy_port.write(self._dummy_sound)
 
 
@@ -162,7 +162,7 @@ class YarpNativeObjectPublisher(YarpPublisher):
         oobj = self._port.prepare()
         oobj.clear()
         oobj.addString(obj)
-        self._port.write()
+        self._port.write(forceStrict=True)
 
 
 @Publishers.register("Properties", "yarp")

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -1,8 +1,7 @@
-import time
+import json
 import logging
-
 import cv2
-import numpy as np
+
 try:
     import yarp
     yarp.Network.init()
@@ -13,7 +12,7 @@ except:
     pass
 
 from wrapify.connect.publishers import Publisher, Publishers, PublisherWatchDog
-from wrapify.utils import JsonEncoder as json
+from wrapify.utils import JsonEncoder
 
 
 @Publishers.register("Image", "yarp")
@@ -160,7 +159,7 @@ class YarpNativeObjectPublisher(Publisher):
     def publish(self, obj):
         if not self.established:
             self.establish()
-        obj = json.dumps(obj)
+        obj = json.dumps(obj, cls=JsonEncoder)
         oobj = self._port.prepare()
         oobj.clear()
         oobj.addString(obj)

--- a/wrapify/publishers/yarp.py
+++ b/wrapify/publishers/yarp.py
@@ -69,7 +69,7 @@ class YarpImagePublisher(YarpPublisher):
         img = cv2.resize(img, dsize=(self.width, self.height), interpolation=cv2.INTER_CUBIC)
         oimg = self._port.prepare()
         oimg.setExternal(img.data, img.shape[1], img.shape[0])
-        self._port.write(forceStrict=True)
+        self._port.write()
 
     def close(self):
         """
@@ -132,7 +132,7 @@ class YarpAudioChunkPublisher(YarpImagePublisher):
         if aud is not None:
             oaud = self._port.prepare()
             oaud.setExternal(aud.data, self.chunk if self.chunk != -1 else oaud.shape[1], self.channels)
-            self._port.write(forceStrict=True)
+            self._port.write()
             self._dummy_port.write(self._dummy_sound)
 
 
@@ -168,7 +168,7 @@ class YarpNativeObjectPublisher(YarpPublisher):
         oobj = self._port.prepare()
         oobj.clear()
         oobj.addString(obj)
-        self._port.write(forceStrict=True)
+        self._port.write()
 
 
 @Publishers.register("Properties", "yarp")

--- a/wrapify/utils.py
+++ b/wrapify/utils.py
@@ -50,7 +50,10 @@ def dynamic_module_import(modules, globals):
             continue
         module_name = module_name[:-3]
         module_name = module_name.replace("/", ".")
-        module = __import__(module_name, fromlist=['*'])
+        try:
+            module = __import__(module_name, fromlist=['*'])
+        except ImportError:
+            continue
         if hasattr(module, '__all__'):
             all_names = module.__all__
         else:

--- a/wrapify/utils.py
+++ b/wrapify/utils.py
@@ -73,7 +73,10 @@ class JsonEncoder(json.JSONEncoder):
 
     def default(self, obj):
 
-        if isinstance(obj, np.ndarray):
+        if isinstance(obj, set):
+            return dict(__wrapify__=('set', list(obj)))
+
+        elif isinstance(obj, np.ndarray):
             with io.BytesIO() as memfile:
                 np.save(memfile, obj)
                 obj_data = base64.b64encode(memfile.getvalue()).decode('ascii')
@@ -100,7 +103,10 @@ class JsonDecodeHook:
             if wrapify is not None:
                 obj_type = wrapify[0]
 
-                if obj_type == 'numpy.ndarray':
+                if obj_type == 'set':
+                    return set(wrapify[1])
+
+                elif obj_type == 'numpy.ndarray':
                     with io.BytesIO(base64.b64decode(wrapify[1].encode('ascii'))) as memfile:
                         return np.load(memfile)
 


### PR DESCRIPTION

- Added fully functional ROS backend

- Revamped the YARP backend to work properly and in more general cases

- Fixed that the YARP dummy sound construct was not actually being sent or used at all

- Added argparse to all examples to select publish/listen and yarp/ros

- Fixed audio source specification bug

- Added a commands file that conveniently lists MWE for all the examples

- Communication activation is now more robustly by specification of method as opposed to assumptions of qualname via string

- No need to unpack sequence when passing multiple registrations to MiddlewareCommunicator.register

- Fix hex id extraction crash / crash when writing text with spaces in the object notifier demo

- Fix video capture/yarp port crashes on delete, close audio dummy ports as well

- Fix that the listener also opened a VideoCapture, blocking and breaking the sender in erratic situations, and also be more careful about dtype

- Support sets, numpy arrays (properly), and torch tensors in native objects

- Controlled (and single instance) backend initialisation and cleanup via middleware singletons

- Support dynamic inclusion of backends (e.g. if YARP isn't installed/available then gracefully just don't load it's backend instead of crash)

- Allow Ctrl+C to safely take down python in almost all situations (previously SIGTERM or higher was always required)

- Publishers/listeners properly await their connections, so it doesn't matter anymore what order you start them and/or race conditions within the code. This also stops the first message from being swallowed and never arriving, which was a huge problem for any kind of attempted reproducibility.

- Fixed many miscellaneous Python language coding mistakes, including better exception/startup/shutdown safety

- Removed name mangling where it was not required

- Added Tensorflow support

- Updated README to reflect additional ROS support

